### PR TITLE
Add missing conda environment file.

### DIFF
--- a/modules/local/multiqc_assemblyscan_plot_data.nf
+++ b/modules/local/multiqc_assemblyscan_plot_data.nf
@@ -1,6 +1,6 @@
 process MULTIQC_ASSEMBLYSCAN_PLOT_DATA {
     label 'process_single'
-    conda "${moduleDir}/environment.yml"
+    conda "${moduleDir}/multiqc_assemblyscan_plot_data_environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/jq:1.6':
         'biocontainers/jq:1.6' }"

--- a/modules/local/multiqc_assemblyscan_plot_data_environment.yml
+++ b/modules/local/multiqc_assemblyscan_plot_data_environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::jq=1.6


### PR DESCRIPTION
`modules/local/multiqc_assemblyscan_plot_data.nf` was missing a conda environment file and for some resason this did not prevent the previous releases.  This PR adds it.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
