### PR TITLE
Allow single strand indexing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - New `--multiqc_thumbs` option to produce alignment thumbnails in the MultiQC report ([#93](https://github.com/nf-core/pairgenomealign/pull/93)).
+- New `--strand` option to index only one strand of the genome, which reduces memory usage at the expense of speed, and suppresses `-/+` alignments ([#97](https://github.com/nf-core/pairgenomealign/pull/97)).
 
 ## [v2.2.3](https://github.com/nf-core/pairgenomealign/releases/tag/2.2.3) "Reitou mikan" - [May 20th 2026]
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -34,8 +34,8 @@ process {
         // -R01: uppercase all sequences and then lowercase simple repeats with tantan
         // -R10: keep original lowercase masking
         // -c: soft-mask lowercase letters
-        // -S2: index both strands
-        ext.args = { "${params.softmask=="tantan" ? '-R01' : '-R11'} -c -u${params.seed} -S2" }
+        // -S2: index both strands, -S1: index the forward strand only.
+        ext.args = { "${params.softmask=="tantan" ? '-R01' : '-R11'} -c -u${params.seed} ${params.strand=="both" ? '-S2' : '-S1'}" }
         publishDir = [
             enabled: false
         ]

--- a/docs/output.md
+++ b/docs/output.md
@@ -49,6 +49,8 @@ Basic statistics on nucleotide content and contig length are collected for align
 
 Genomes are aligned witn [`lastal`](https://gitlab.com/mcfrith/last/-/blob/main/doc/lastal.rst) after alignment parameters have been determined with [`last-train`](https://gitlab.com/mcfrith/last/-/blob/main/doc/last-train.rst). _**Many-to-many**_ alignments are progressively converted to _**one-to-one**_ with [`last-split`](https://gitlab.com/mcfrith/last/-/blob/main/doc/last-split.rst).
 
+To speed up alignment, both strands of the target genome are indexed. This doubles memory usage and may produce output files containing `-/+` alignments, which are not supported by some downstream pipelines. To disable this behavior, use `--strand forward`.
+
 ### Dot plots
 
 <details markdown="1">

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,6 +62,7 @@ params {
     // Indexing options
     seed                       = 'YASS'
     softmask                   = 'tantan'
+    strand                     = 'both'
 
     // Misc options
     skip_assembly_qc           = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -86,6 +86,14 @@
                     "description": "Customise the way to mask the _target_ genome.",
                     "default": "tantan",
                     "fa_icon": "fas fa-theater-masks"
+                },
+                "strand": {
+                    "type": "string",
+                    "default": "both",
+                    "fa_icon": "fas fa-grip-lines",
+                    "description": "Index both strand, or just one.",
+                    "enum": ["both", "forward"],
+                    "help_text": "This is the `-S` parameter of `lastdb`. By default, both strands are indexed.  This roughly doubles the speed of the alignment, but also the memory usage. Also, it causes the presence of -/+ alignments in some output files, which is not supported by toolchains. Turn it off by setting it to `forward`."
                 }
             }
         },


### PR DESCRIPTION
Closes #97

To speed up alignment, both strands of the target genome are indexed. This doubles memory usage and may produce output files containing `-/+` alignments, which are not supported by some downstream pipelines. To disable this behavior, the `--strand forward` option is given.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
