### PR TITLE
Optional alignment thumbnails in the MultiQC report.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.3.0dev
 
+### `Added`
+
+- New `--multiqc_thumbs` option to produce alignment thumbnails in the MultiQC report ([#93](https://github.com/nf-core/pairgenomealign/pull/93)).
+
 ## [v2.2.3](https://github.com/nf-core/pairgenomealign/releases/tag/2.2.3) "Reitou mikan" - [May 20th 2026]
 
 ### `Fixed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -126,6 +126,20 @@ process {
         ]
     }
 
+    withName: 'MULTIQC_THUMBS' {
+        errorStrategy = { task.exitStatus in ((130..145) + 104 + (175..177)) ? 'retry' : 'finish' }
+        ext.prefix    = { "${meta.id}.o2o_thumb" }
+        ext.args      = { "--sort2=3 --strands2=1 --width=${params.multiqc_thumbs} --height=${params.multiqc_thumbs} --fontsize=1 --border-pixel=0" }
+        publishDir    = [ enabled: false ]
+    }
+
+    withName: 'MULTIQC_THUMBS_HTML' {
+        publishDir = [
+            path: { "${params.outdir}/multiqc/alignment_thumbs" },
+            mode: params.publish_dir_mode,
+        ]
+    }
+
     withName: 'SAMTOOLS_BGZIP' {
         publishDir = [
             path: { "${params.outdir}/alignment" },

--- a/modules/local/multiqc_thumbs_html/main.nf
+++ b/modules/local/multiqc_thumbs_html/main.nf
@@ -1,0 +1,50 @@
+process MULTIQC_THUMBS_HTML {
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1b/1bef8af6be88c5733461959c46ac8ef73d18f65277f62a1695d0e1633054f9c2/data'
+        : 'community.wave.seqera.io/library/multiqc:1.34--db7c73dae76bc9e6'}"
+
+    input:
+    path(pngs)
+    val(width)
+
+    output:
+    path("*_mqc.html"), emit: html
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    out_file="alignment_thumbs_mqc.html"
+
+    # MultiQC headers (MUST be raw, not escaped)
+    echo "<!--"                                    >  \${out_file}
+    echo "id: alignment_thumbs"                    >> \${out_file}
+    echo "section_name: Alignment thumbnails"      >> \${out_file}
+    echo "description: Alignment thumbnail images" >> \${out_file}
+    echo "-->"                                     >> \${out_file}
+    # HTML content (NOT escaped)
+    echo "<div>"                                   >> \${out_file}
+
+    for img in ${pngs}; do
+        name=\$(basename "\$img")
+        label=\${name%.o2o_thumb.png}
+
+        b64=\$(base64 -w 0 "\$img")
+
+        echo "<div style='display:inline-block; margin:5px;'>" >> \${out_file}
+        echo "<img src='data:image/png;base64,\${b64}' width='${width}' title='\${label}'>" >> \${out_file}
+        echo "</div>" >> \${out_file}
+    done
+
+    echo "</div>"                                  >> \${out_file}
+    """
+
+    stub:
+    """
+    touch alignment_thumbs_mqc.html
+    """
+}

--- a/modules/local/multiqc_thumbs_html/main.nf
+++ b/modules/local/multiqc_thumbs_html/main.nf
@@ -33,7 +33,7 @@ process MULTIQC_THUMBS_HTML {
         name=\$(basename "\$img")
         label=\${name%.o2o_thumb.png}
 
-        b64=\$(base64 -w 0 "\$img")
+        b64=\$(base64 "\$img" | tr -d '\n')
 
         echo "<div style='display:inline-block; margin:5px;'>" >> \${out_file}
         echo "<img src='data:image/png;base64,\${b64}' width='${width}' title='\${label}'>" >> \${out_file}

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params {
     dotplot_height             = 10000  // To allow scaling according to target genome
     dotplot_options            = ''
     dotplot_width              = 1000   // last-dotplot default
+    multiqc_thumbs             = 0      // Turn off by default
 
     // References
     genome                     = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -189,6 +189,14 @@
                     "description": "Remove isolated alignments with the `maf-filter` tool.",
                     "help_text": "The filter often removes noise in the plots, but in some cases can also remove too much alignments. Be careful when interpreting the results.",
                     "fa_icon": "fas fa-filter"
+                },
+                "multiqc_thumbs": {
+                    "type": "integer",
+                    "default": 0,
+                    "fa_icon": "fas fa-th",
+                    "description": "Size of the alignments thumbnails in MultiQC (default 0 turns it off; 100 is a good value to start with).",
+                    "help_text": "Produces small pairwise alignment plots to be displayed in MultiQC. The value is the number of pixels given to the biggest genome. Labels and sequence boundaries are turned off.",
+                    "minimum": 0
                 }
             },
             "fa_icon": "fas fa-cogs"

--- a/workflows/pairgenomealign.nf
+++ b/workflows/pairgenomealign.nf
@@ -6,6 +6,8 @@
 
 include { ASSEMBLYSCAN                     } from '../modules/nf-core/assemblyscan/main'
 include { LAST_MAFCONVERT as ALIGNMENT_EXP } from '../modules/nf-core/last/mafconvert/main'
+include { LAST_DOTPLOT as MULTIQC_THUMBS   } from '../modules/nf-core/last/dotplot/main'
+include { MULTIQC_THUMBS_HTML              } from '../modules/local/multiqc_thumbs_html/main'
 include { MULTIQC_ASSEMBLYSCAN_PLOT_DATA   } from '../modules/local/multiqc_assemblyscan_plot_data/main'
 include { PAIRALIGN_M2M                    } from '../subworkflows/local/pairalign_m2m/main'
 include { SEQTK_CUTN as CUTN_TARGET        } from '../modules/nf-core/seqtk/cutn/main'
@@ -114,6 +116,22 @@ workflow PAIRGENOMEALIGN {
             ch_targetgenome_gzi,
             ch_targetgenome_dic
         )
+    }
+
+    if (params.multiqc_thumbs != 0) {
+        MULTIQC_THUMBS(
+            pairalign_out.o2o.map { x -> [x[0], x[1], []] },
+            [[],[]],
+            "png",
+            params.dotplot_filter
+        )
+        MULTIQC_THUMBS_HTML(
+            MULTIQC_THUMBS.out.plot
+                .map { meta, file -> file }
+                .collect(),
+            params.multiqc_thumbs
+        )
+        ch_multiqc_files = ch_multiqc_files.mix(MULTIQC_THUMBS_HTML.out.html)
     }
 
     // Collate and save software versions


### PR DESCRIPTION
Adds a new option `--multiqc_thumbs` that defines a pixel size for alignment thumbnails to be displayed in the MultiQC report.  Defaults to zero for no plots.

Closes #93

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
