### PR TITLE
Add a `--query` option for when there is only one query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `--multiqc_thumbs` option to produce alignment thumbnails in the MultiQC report ([#93](https://github.com/nf-core/pairgenomealign/pull/93)).
 - New `--strand` option to index only one strand of the genome, which reduces memory usage at the expense of speed, and suppresses `-/+` alignments ([#97](https://github.com/nf-core/pairgenomealign/pull/97)).
+- New `--query` and `--queryName` convenience options to skip samplesheet creation when there is only one _query_ genome to align ([#112](https://github.com/nf-core/pairgenomealign/pull/112)).
+
+### `Parameters`
+
+| Old parameter | New parameter      |
+| ------------- | ------------------ |
+|               | `--multiqc_thumbs` |
+|               | `--query`          |
+|               | `--queryName`      |
+|               | `--strand`         |
 
 ## [v2.2.3](https://github.com/nf-core/pairgenomealign/releases/tag/2.2.3) "Reitou mikan" - [May 20th 2026]
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ You need at least two genomes, a _target_, which will be indexed, and one or mor
 
 The target genome sequence is taken from a FASTA-formated file passed by the `--target` parameter. Its masking information (sequences in lower-case letters) is first discarded, and then simple repeats (like `cacacacacacacacac`) are converted to lower-case (`lastdb -R01`). The lowercased letters in the _target_ **and** in the _query_ will be excluded for initial matches (`lastdb -c`). Both strands of the genome are indexed (`lastdb -S2`).
 
-### Samplesheet for query genome(s)
+### Query genome(s)
 
 You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use the `--input` parameter to specify its location. It has to be a comma-separated file with 2 columns, a header row and single or multiple sample rows (genome samples) as shown in the examples below.
 
@@ -35,6 +35,8 @@ Each row represents a fasta file. Use multiple rows as in the example above to a
 | `fasta`  | Full path to Fasta/fa/gz file                                                                |
 
 An [example samplesheet](../assets/samplesheet_full.csv) has been provided with the pipeline.
+
+For your convenience when you have only one _query_ genome, you can skip the creation of the samplesheet and use the `--query` and `--queryName` options instead of `--input`.
 
 ## Options
 

--- a/main.nf
+++ b/main.nf
@@ -70,6 +70,22 @@ workflow NFCORE_PAIRGENOMEALIGN {
 workflow {
 
     main:
+    // Validate mutually exclusive parameters
+    if (params.input && params.query) {
+        error """
+        ❌ Invalid parameter combination
+
+        You provided both:
+          --input  (sample sheet)
+          --query  (single genome)
+
+        These options are mutually exclusive.
+
+        👉 Use only one:
+           • --input : for multiple samples via a sample sheet
+           • --query : for a single query genome (no sample sheet required)
+        """
+    }
     //
     // SUBWORKFLOW: Run initialisation tasks
     //

--- a/main.nf
+++ b/main.nf
@@ -91,11 +91,21 @@ workflow {
         .map { file_obj -> [ [id:params.targetName], file_obj] }
         .set { ch_target }
 
+    if ( params.query ) {
+        channel
+            .value( params.query )
+            .map { filename -> file(filename, checkIfExists: true) }
+            .map { file_obj -> [ [id:params.queryName],  file_obj] }
+            .set { ch_query }
+    } else {
+        ch_query = PIPELINE_INITIALISATION.out.samplesheet
+    }
+
     //
     // WORKFLOW: Run main workflow
     //
     NFCORE_PAIRGENOMEALIGN (
-        PIPELINE_INITIALISATION.out.samplesheet,
+        ch_query,
         ch_target
     )
     //

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,8 +10,9 @@
 params {
 
     // Mandatory options
-    input                      = null
     target                     = null
+    input                      = null // Required if --query is not given
+    query                      = null // Required if --input is not given
 
     // Dotplot parameters
     skip_dotplot_m2m           = false
@@ -68,6 +69,7 @@ params {
     // Misc options
     skip_assembly_qc           = false
     targetName                 = 'target'
+    queryName                  = 'query'
     m2m                        = false
 
     // Alignment options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,8 +10,23 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "target", "outdir"],
+            "required": ["target", "outdir"],
+            "oneOf": [{ "required": ["input"] }, { "required": ["query"] }],
             "properties": {
+                "target": {
+                    "type": "string",
+                    "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
+                    "format": "file-path",
+                    "description": "Path or URL to a FASTA genome file for the _target_ genome.",
+                    "fa_icon": "far fa-file-code"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Path or URL to a FASTA genome file for the _query_ genome.",
+                    "fa_icon": "fas fa-file-code",
+                    "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
+                    "help_text": "Simpler than creating a sample sheet when there is only one _query_ genome."
+                },
                 "input": {
                     "type": "string",
                     "format": "file-path",
@@ -23,18 +38,18 @@
                     "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/pairgenomealign/usage#samplesheet-input).",
                     "fa_icon": "fas fa-file-csv"
                 },
-                "target": {
-                    "type": "string",
-                    "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
-                    "format": "file-path",
-                    "description": "Path or URL to a FASTA genome file for the _target_ genome.",
-                    "fa_icon": "far fa-file-code"
-                },
                 "targetName": {
                     "type": "string",
                     "default": "target",
                     "help_text": "By default the _target_ genome is named `target` and this name is concatenated with the sample IDs using `___` as a separator to construct alignment file names. Use this option to provide a more informative name for the target genome.",
                     "description": "Target genome name.",
+                    "fa_icon": "fas fa-file-signature"
+                },
+                "queryName": {
+                    "type": "string",
+                    "default": "query",
+                    "description": "Query genome name.",
+                    "help_text": "By default the _query_ genome is named `query` and this name is concatenated with the sample IDs using `___` as a separator to construct alignment file names. Use this option to provide a more informative name for the query genome.",
                     "fa_icon": "fas fa-file-signature"
                 },
                 "skip_assembly_qc": {

--- a/subworkflows/local/utils_nfcore_pairgenomealign_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_pairgenomealign_pipeline/main.nf
@@ -107,9 +107,13 @@ workflow PIPELINE_INITIALISATION {
     // Create channel from input file provided through params.input
     //
 
+    if ( ! params.query ) {
     channel
         .fromList(samplesheetToList(params.input, "${projectDir}/assets/schema_input.json"))
         .set { ch_samplesheet }
+    } else {
+        ch_samplesheet = channel.empty()
+    }
 
     emit:
     samplesheet = ch_samplesheet


### PR DESCRIPTION
Closes #112

This is inspired by nf-co.re/demultiplex, which also allows to bypass --input and provide single files directly.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
