### PR TITLE
fix: escape blasttab plus in schema regex

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -162,7 +162,7 @@
                     "type": "string",
                     "default": "no_export",
                     "description": "Convert the final _one-to-one_ alignment to a different format than MAF.",
-                    "pattern": "^((no_export|axt|bam|bcf|bed|blast|blasttab|blasttab+|chain|cram|gff|html|psl|sam|tab)?,?)*(?<!,)$",
+                    "pattern": "^((no_export|axt|bam|bcf|bed|blast|blasttab|blasttab\\+|chain|cram|gff|html|psl|sam|tab)?,?)*(?<!,)$",
                     "fa_icon": "fas fa-file-export",
                     "help_text": "Multiple formats separated with commas. Supported formats are `axt`, `bam`, `bcf`, `bed`, `blast`, `blasttab`, `blasttab+`, `chain`, `cram`, `gff`, `html`, `psl`, `sam` and `tab`. This is useful for downstream tools that do not parse MAF. The files in text format are always compressed with `gzip`."
                 },


### PR DESCRIPTION
## Summary

- escape the literal `+` in the documented `blasttab+` export format
- stop the schema regex from rejecting `blasttab+` and accepting invalid values such as `blasttabb`

Closes #136.

## Validation

- `python -m json.tool nextflow_schema.json`
- Python and JavaScript regex boundary checks for valid, invalid, and comma-separated values
- `git diff --check`

## PR checklist

- [x] This description explains the bug and the one-token schema correction.
- [x] The change is limited to the existing schema regex; pipeline runtime tests and test-data changes are not applicable.
