### PR TITLE
Revert RY4 seed change in full tests and one template change

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Setup apptainer
       if: contains(inputs.profile, 'singularity')
-      uses: eWaterCycle/setup-apptainer@4bb22c52d4f63406c49e94c804632975787312b3 # v2.0.0
+      uses: eWaterCycle/setup-apptainer@3f706d898c9db585b1d741b4692e66755f3a1b40 # v2
 
     - name: Set up Singularity
       if: contains(inputs.profile, 'singularity')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v3.0.3](https://github.com/nf-core/pairgenomealign/releases/tag/3.0.3) "Kanten" - [July 27th 2026]
+## [v3.0.3](https://github.com/nf-core/pairgenomealign/releases/tag/3.0.3) "Kanten" - [July 29th 2026]
 
 ### `Fixed`
 
 - Remove vulnerable PR-comment artifact pattern – no change in the pipeline computations ([#145](https://github.com/nf-core/pairgenomealign/pull/145)).
 - Conforms to [nf-core template version `4.0.3`](https://github.com/nf-core/tools/releases/tag/4.0.3) ([#144](https://github.com/nf-core/pairgenomealign/pull/144)).
+- In the `full` test suite on primate genomes, revert aligment seed from `RY4` to `RY128` to match the AWS resources that we are given ([#148](https://github.com/nf-core/pairgenomealign/pull/148)).
 
 ## [v3.0.2](https://github.com/nf-core/pairgenomealign/releases/tag/3.0.2) "Tokoroten shiki" - [July 16th 2026]
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -23,7 +23,7 @@ params {
     targetName = 'Homo_sapiens_GRCh38.p14'
 
     // Other parameters
-    seed = 'RY4'
+    seed = 'RY128'
     multi_cram = true
 
     // Genome references


### PR DESCRIPTION
Two one-line reverts to fix release PR.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
