### PR TITLE
Add `manifest.diagram` to `nextflow.config`

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -307,6 +307,7 @@ manifest {
     nextflowVersion = '!>=26.04.0'
     version         = '3.0.5dev'
     doi             = ''
+    diagram         = 'docs/images/pairgenomealign-tubemap.png'
 }
 
 // Nextflow plugins


### PR DESCRIPTION
Adds the new `manifest.diagram` config attribute, pointing at the pipeline overview diagram.

See nf-core/tools#4460 for background: `manifest.diagram` gives a canonical location for the metro map, so that downstream consumers can find it. We'll use it for the nf-core website soon, for example. The new config option won't be released until Nextflow `26.10`, but older versions ignore unknown manifest fields, so it's safe to set in any pipeline today.