### PR TITLE
Revised metro map

### DIFF
--- a/docs/images/pairgenomealign-tubemap.svg
+++ b/docs/images/pairgenomealign-tubemap.svg
@@ -2,1635 +2,2083 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="332.54938mm"
-   height="167.17039mm"
-   viewBox="0 0 332.54937 167.17039"
+   width="299.35507mm"
+   height="149.04529mm"
+   viewBox="0 0 299.35507 149.04529"
    version="1.1"
    id="svg1"
-   sodipodi:docname="pairgenomealign-tubemap.svg"
+   sodipodi:docname="pairgenomealign-tubemap.new.svg"
    inkscape:version="1.4.3 (0d15f75042, 2025-12-25)"
-   inkscape:export-filename="pairgenomealign-tubemap.png"
-   inkscape:export-xdpi="121.55262"
-   inkscape:export-ydpi="121.55262"
-   xml:space="preserve"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
-     id="namedview319"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
      pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
-     inkscape:pageopacity="1"
+     inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
-     showgrid="false"
-     inkscape:zoom="0.7071068"
-     inkscape:cx="490.73209"
-     inkscape:cy="284.25692"
+     inkscape:zoom="1.0440797"
+     inkscape:cx="513.37078"
+     inkscape:cy="354.37908"
      inkscape:window-width="2560"
      inkscape:window-height="1403"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1"
-     showguides="true" /><defs
-     id="defs1"><rect
-       x="44.9795"
-       y="700.06897"
-       width="105.93453"
-       height="78.519043"
-       id="rect7816" /><linearGradient
-       id="swatch70"><stop
-         style="stop-color:#241964;stop-opacity:1;"
-         offset="0"
-         id="stop70" /></linearGradient><linearGradient
-       id="swatch69"><stop
-         style="stop-color:#000000;stop-opacity:0.86430682;"
-         offset="0"
-         id="stop69" /></linearGradient><marker
+     inkscape:current-layer="g38" />
+  <defs
+     id="defs1">
+    <rect
+       x="1263.7552"
+       y="-157.12285"
+       width="735.4975"
+       height="375.19852"
+       id="rect37" />
+    <marker
        style="overflow:visible"
        id="Triangle"
        refX="0"
        refY="0"
        orient="auto-start-reverse"
-       markerWidth="0.001"
-       markerHeight="0.001"
+       inkscape:stockid="Triangle arrow"
+       markerWidth="1"
+       markerHeight="1"
        viewBox="0 0 1 1"
-       preserveAspectRatio="xMidYMid"><path
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
          transform="scale(0.5)"
          style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
          d="M 5.77,0 -2.88,5 V -5 Z"
-         id="path135" /></marker><linearGradient
-       xlink:href="#a-8"
-       id="linearGradient4391-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(48.296794,34.573734,-37.733185,44.252838,11711.582,3142.9128)"
-       x2="1" /><linearGradient
-       id="a-8"
-       x2="1"
-       gradientTransform="matrix(47.34875,36.9925,-36.9925,47.34875,344.325,162.1875)"
-       gradientUnits="userSpaceOnUse"><stop
-         stop-color="#0c542a"
-         offset="0"
-         id="stop15-7" /><stop
-         stop-color="#0c542a"
-         offset=".21472"
-         id="stop17-3" /><stop
-         stop-color="#25af64"
-         offset=".57995"
-         id="stop19-8" /><stop
-         stop-color="#25af64"
-         offset=".84663"
-         id="stop21-8" /><stop
-         stop-color="#25af64"
-         offset="1"
-         id="stop23-9" /></linearGradient><linearGradient
-       xlink:href="#a-8"
-       id="linearGradient4332-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(47.383845,33.920191,-37.019919,43.416332,11414.897,2743.0799)"
-       x2="1" /><linearGradient
-       xlink:href="#a-8-7"
-       id="linearGradient4391-8-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(60.204045,34.573734,-47.036049,44.252838,12624.813,2830.361)"
-       x2="1" /><linearGradient
-       id="a-8-7"
-       x2="1"
-       gradientTransform="matrix(47.34875,36.9925,-36.9925,47.34875,344.325,162.1875)"
-       gradientUnits="userSpaceOnUse"><stop
-         stop-color="#0c542a"
-         offset="0"
-         id="stop15-7-6" /><stop
-         stop-color="#0c542a"
-         offset=".21472"
-         id="stop17-3-0" /><stop
-         stop-color="#25af64"
-         offset=".57995"
-         id="stop19-8-0" /><stop
-         stop-color="#25af64"
-         offset=".84663"
-         id="stop21-8-9" /><stop
-         stop-color="#25af64"
-         offset="1"
-         id="stop23-9-2" /></linearGradient><rect
+         id="path135" />
+    </marker>
+    <rect
        x="44.9795"
        y="700.06897"
        width="105.93453"
        height="78.519043"
-       id="rect7816-5" /><linearGradient
-       xlink:href="#a-8-5"
-       id="linearGradient4391-8-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(48.296794,34.573734,-37.733185,44.252838,11711.582,3142.9128)"
-       x2="1" /><linearGradient
-       id="a-8-5"
-       x2="1"
-       gradientTransform="matrix(47.34875,36.9925,-36.9925,47.34875,344.325,162.1875)"
-       gradientUnits="userSpaceOnUse"><stop
-         stop-color="#0c542a"
-         offset="0"
-         id="stop15-7-69" /><stop
-         stop-color="#0c542a"
-         offset=".21472"
-         id="stop17-3-3" /><stop
-         stop-color="#25af64"
-         offset=".57995"
-         id="stop19-8-7" /><stop
-         stop-color="#25af64"
-         offset=".84663"
-         id="stop21-8-4" /><stop
-         stop-color="#25af64"
-         offset="1"
-         id="stop23-9-5" /></linearGradient><linearGradient
-       xlink:href="#a-8-5"
-       id="linearGradient4332-6-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(47.383845,33.920191,-37.019919,43.416332,11414.897,2743.0799)"
-       x2="1" /><linearGradient
-       id="linearGradient8337"
-       x2="1"
-       gradientTransform="matrix(47.34875,36.9925,-36.9925,47.34875,344.325,162.1875)"
-       gradientUnits="userSpaceOnUse"><stop
-         stop-color="#0c542a"
-         offset="0"
-         id="stop8327" /><stop
-         stop-color="#0c542a"
-         offset=".21472"
-         id="stop8329" /><stop
-         stop-color="#25af64"
-         offset=".57995"
-         id="stop8331" /><stop
-         stop-color="#25af64"
-         offset=".84663"
-         id="stop8333" /><stop
-         stop-color="#25af64"
-         offset="1"
-         id="stop8335" /></linearGradient><linearGradient
+       id="rect7816" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="105.93453"
+       height="78.519043"
+       id="rect7816-5" />
+    <linearGradient
        id="f"
        x2="1"
        gradientTransform="matrix(37.935665,29.63859,-29.63859,37.935665,295.72189,166.19726)"
-       gradientUnits="userSpaceOnUse"><stop
+       gradientUnits="userSpaceOnUse">
+      <stop
          id="stop12"
          offset="0"
-         stop-color="#0c542a" /><stop
+         stop-color="#0c542a" />
+      <stop
          id="stop14"
          offset=".215"
-         stop-color="#0c542a" /><stop
+         stop-color="#0c542a" />
+      <stop
          id="stop16"
          offset=".58"
-         stop-color="#25af64" /><stop
+         stop-color="#25af64" />
+      <stop
          id="stop18"
          offset=".847"
-         stop-color="#25af64" /><stop
+         stop-color="#25af64" />
+      <stop
          id="stop20"
          offset="1"
-         stop-color="#25af64" /></linearGradient><clipPath
-       id="e"><path
-         id="path9"
-         d="m280.17 136.33-21.5-21.584h61v21.584z" /></clipPath><rect
+         stop-color="#25af64" />
+    </linearGradient>
+    <rect
        x="44.9795"
        y="700.06897"
        width="105.93453"
        height="78.519043"
-       id="rect22" /></defs><g
+       id="rect22" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="346.29385"
+       height="38.937199"
+       id="rect28" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="105.93453"
+       height="78.519043"
+       id="rect7816-0" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="105.93453"
+       height="78.519043"
+       id="rect7816-5-7" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="105.93453"
+       height="78.519043"
+       id="rect22-5" />
+    <rect
+       x="44.9795"
+       y="700.06897"
+       width="346.29385"
+       height="38.937199"
+       id="rect28-8" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-14.374769,-40.906011)"><path
-       style="fill:none;fill-opacity:1;stroke:#999999;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.76, 0.38;stroke-dashoffset:165.3;stroke-opacity:1"
-       d="m 129.02898,147.2403 12.89909,6.85741 -13.87912,10.59285 0.0167,-75.947785 -64.717587,0.206729 -0.171674,-11.170811"
-       id="path78-6"
-       sodipodi:nodetypes="cccccc" /><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 191.95341,96.91538 124.00054,0.45765 v 0 0 0 0"
-       id="path69"
-       sodipodi:nodetypes="cccccc" /><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 191.95341,118.01537 h 124.00054 v 0 0"
-       id="path6843"
-       sodipodi:nodetypes="cccc" /><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 191.95341,153.32678 h 124.00054 v 0 0"
-       id="path68"
-       sodipodi:nodetypes="cccc" /><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 191.95341,178.68399 h 124.00054 v 0 0"
-       id="path9644"
-       sodipodi:nodetypes="cccc" /><path
-       style="fill:none;fill-opacity:1;stroke:#999999;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.76, 0.38;stroke-dashoffset:165.3;stroke-opacity:1"
-       d="m 188.91606,174.01539 -41.21327,-5.08812 -5.16526,-16.38481"
-       id="path78-0-3"
-       sodipodi:nodetypes="ccc" /><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="149.78886"
-       y="154.70258"
-       id="text677"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="149.78886"
-         y="154.70258"
-         id="tspan675">last/dotplot</tspan></text><g
-       id="g3956"
-       transform="translate(30.115616,-46.550633)"><path
-         style="fill:none;stroke:#f796f4;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 272.28895,200.14243 0.0656,10.74866"
-         id="path3939"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#f796f4;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,164.22256 11.86432,8.52316 1.14683,12.01584"
-         id="path1548"
-         sodipodi:nodetypes="ccc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect918-18-7"
-         width="1.805621"
-         height="9.3641844"
-         x="-185.16084"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><path
-         style="fill:none;stroke:#f796f4;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,190.78843 10.7831,7.25598"
-         id="path3185"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#f796f4;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,170.18329 0.0656,66.29015"
-         id="path3187"
-         sodipodi:nodetypes="cc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect3189"
-         width="1.805621"
-         height="9.3641844"
-         x="-211.72672"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g3195"
-         transform="translate(23.93628,27.204738)"><g
-           id="g3193"><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse3191"
-             cx="247.75914"
-             cy="172.67381"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse6273"
-             cx="234.68857"
-             cy="198.03119"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /></g></g></g><g
-       id="g3984"
-       transform="translate(-26.439136,-46.550633)"><path
-         style="fill:none;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 272.28895,200.14243 0.0656,10.74866"
-         id="path3960"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,164.22256 11.86432,8.52316 1.14683,12.01584"
-         id="path3962"
-         sodipodi:nodetypes="ccc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect3964"
-         width="1.805621"
-         height="9.3641844"
-         x="-185.16084"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g3970"
-         transform="translate(23.93628,0.63886604)"><g
-           id="g3968" /></g><path
-         style="fill:none;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,190.78843 10.7831,7.25598"
-         id="path3972"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,170.18329 0.0656,66.29015"
-         id="path3974"
-         sodipodi:nodetypes="cc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect3976"
-         width="1.805621"
-         height="9.3641844"
-         x="-211.72672"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g3982"
-         transform="translate(23.93628,27.204738)"><g
-           id="g3980"><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse3978"
-             cx="247.75914"
-             cy="172.67381"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse6275"
-             cx="234.68857"
-             cy="198.03119"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /></g></g></g><g
-       id="g4012"
-       transform="translate(1.8382404,-46.550633)"><path
-         style="fill:none;stroke:#24b064;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 272.28895,200.14243 0.0656,10.74866"
-         id="path3988"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#24b064;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,164.22256 11.86433,8.52316 1.14682,12.01584"
-         id="path3990"
-         sodipodi:nodetypes="ccc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect3992"
-         width="1.805621"
-         height="9.3641844"
-         x="-185.16084"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g3998"
-         transform="translate(23.93628,0.63886604)"><g
-           id="g3996" /></g><path
-         style="fill:none;stroke:#24b064;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,190.78843 10.7831,7.25598"
-         id="path4000"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;stroke:#24b064;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,146.61882 0.0656,89.85462"
-         id="path4002"
-         sodipodi:nodetypes="cc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect4004"
-         width="1.805621"
-         height="9.3641844"
-         x="-211.72672"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g4010"
-         transform="translate(23.93628,27.204738)"><g
-           id="g4008"><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse4006"
-             cx="247.75914"
-             cy="172.67381"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse6277"
-             cx="234.68857"
-             cy="198.03119"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /></g></g></g><g
-       id="g4040"
-       transform="translate(-68.021682,-46.550633)"><path
-         style="fill:#8d1964;fill-opacity:1;stroke:#8d1964;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 272.28895,200.14243 0.0656,10.74866"
-         id="path4016"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:none;fill-opacity:1;stroke:#8d1964;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,164.22256 11.86432,8.52316 1.14683,12.01584"
-         id="path4018"
-         sodipodi:nodetypes="ccc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect4020"
-         width="1.805621"
-         height="9.3641844"
-         x="-185.16084"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><path
-         style="fill:#8d1964;fill-opacity:1;stroke:#8d1964;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,190.78843 10.7831,7.25598"
-         id="path4028"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:#8d1964;fill-opacity:1;stroke:#8d1964;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 259.3434,170.18329 0.0656,66.29015"
-         id="path4030"
-         sodipodi:nodetypes="cc" /><rect
-         style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-         id="rect4032"
-         width="1.805621"
-         height="9.3641844"
-         x="-211.72672"
-         y="267.89996"
-         ry="2.6458333"
-         rx="2.6458333"
-         transform="rotate(-90)" /><g
-         id="g4038"
-         transform="translate(23.93628,27.204738)"><g
-           id="g4036"><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse4034"
-             cx="247.75914"
-             cy="172.67381"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><ellipse
-             style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse6279"
-             cx="234.68857"
-             cy="198.03119"
-             rx="5.9872503"
-             ry="6.2987328"
-             transform="matrix(1,0,0.00362725,0.99999342,0,0)" /></g></g></g><path
-       style="fill:none;stroke:#24b064;stroke-width:3.47541;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 233.38505,116.77136 27.8349,-19.35521"
-       id="path6120"
-       sodipodi:nodetypes="cc" /><path
-       style="fill:#8d1964;fill-opacity:1;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.76, 0.38;stroke-dashoffset:165.3;stroke-opacity:1"
-       d="M 232.47519,117.03706 192.18115,97.205548"
-       id="path6113"
-       sodipodi:nodetypes="cc" /><g
-       id="g2985"
-       transform="matrix(0.82868225,-0.64152186,1.5099622,0.35207358,-83.059076,173.12852)"><path
-         style="fill:#808000;fill-opacity:1;stroke:#808000;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 187.30978,122.75682 1.57227,-44.633001"
-         id="path2979"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 189.39389,122.75682 1.57227,-44.633001"
-         id="path2981"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:#7eb2dd;fill-opacity:1;stroke:#7eb2dd;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 191.478,122.75682 1.57227,-44.633001"
-         id="path2983"
-         sodipodi:nodetypes="cc" /></g><g
-       id="g2969"><path
-         style="fill:#808000;fill-opacity:1;stroke:#808000;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 189.06569,101.35234 188.88205,78.123819"
-         id="path83"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 191.1498,101.35234 190.96616,78.123819"
-         id="path602"
-         sodipodi:nodetypes="cc" /><path
-         style="fill:#7eb2dd;fill-opacity:1;stroke:#7eb2dd;stroke-width:1.9;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 193.23391,101.35234 193.05027,78.123819"
-         id="path604"
-         sodipodi:nodetypes="cc" /></g><path
-       style="fill:#8d1964;fill-opacity:1;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 191.28545,101.35113 0.0913,13.78124"
-       id="path1937"
-       sodipodi:nodetypes="cc" /><path
-       style="fill:none;stroke:#24b064;stroke-width:3.47541;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 289.0291,116.77136 261.1942,97.41615"
-       id="path924"
-       sodipodi:nodetypes="cc" /><path
-       style="display:none;fill:none;stroke:#7eb2dd;stroke-width:2.64582;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 165.13568,77.764706 120.38761,77.17442"
-       id="path8" /><g
+     transform="translate(0.69479143,0.91123941)">
+    <g
        id="g6"
-       transform="matrix(0.7621257,0,0,0.93099315,-139.49792,-19.590436)"
-       style="stroke-width:3.20536;stroke-dasharray:none"><path
-         style="fill:none;stroke:#7eb2dd;stroke-width:3.20536;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:3.2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-         d="m 256.68383,89.400269 176.61536,0.720973 0.10264,14.822918"
-         id="path88"
-         sodipodi:nodetypes="ccc" /></g><g
-       id="g44"
-       transform="matrix(1.2981703,0,0,0.99966585,-3.8623643,22.777041)"
-       style="stroke-width:3.1;stroke-dasharray:none"><path
-         style="fill:none;stroke:#000000;stroke-width:3.33573;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+       transform="matrix(0.4498845,0,0,0.54956733,-88.28731,-0.60652509)"
+       style="stroke-width:3.20536;stroke-dasharray:none" />
+    <g
+       id="g38"
+       transform="translate(0.30328733,2.3960473)">
+      <path
+         style="fill:none;fill-opacity:1;stroke:#233164;stroke-width:2.09453;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:2.09453, 0.418906;stroke-dashoffset:0;stroke-opacity:0.992157"
+         d="M 175.68935,84.075922 203.34386,52.393474"
+         id="path11"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#233164;stroke-width:2.18442;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.992157"
+         d="M 175.3389,84.381822 190.8442,66.791504"
+         id="path29"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#999999;stroke-width:2.3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.69000007,1.14999581;stroke-dashoffset:98.89997736;stroke-opacity:1"
+         d="m 267.37183,53.079567 0.20612,48.229513 -14.42479,12.18418 -214.818563,0.0966 L 25.244035,99.603121 24.757523,52.86962"
+         id="path78-6"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#24b064;stroke-width:2.09453;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+         d="M 164.6566,96.646341 176.9498,82.620248"
+         id="path12"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:#808000;fill-opacity:1;stroke:#7eb2dd;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:1"
+         d="m 136.92504,57.542405 12.93685,42.396406"
+         id="path10"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:#808000;fill-opacity:1;stroke:#808000;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:1"
+         d="m 138.85159,54.987281 12.93685,42.382815"
+         id="path9"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:#7eb2dd;fill-opacity:1;stroke:#808000;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:1"
+         d="M 127.36261,54.930043 H 151.0186"
+         id="path4"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:#7eb2dd;fill-opacity:1;stroke:#7eb2dd;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:1"
+         d="M 30.810891,57.518334 H 151.0186"
+         id="path3"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:0.992157"
+         d="m 140.85501,52.811909 12.85997,41.989472"
          id="path2"
-         sodipodi:nodetypes="ccc" /></g><rect
-       style="fill:#ffffff;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect918-0"
-       width="1.805621"
-       height="9.3641844"
-       x="54.3218"
-       y="73.707253"
-       ry="2.6458333"
-       rx="2.6458333" /><g
-       id="g7"
-       transform="matrix(0.17674984,0.30899067,-0.95828269,0.16553372,206.43374,-49.649807)"
-       style="stroke-width:4.03224;stroke-dasharray:none"><g
-         id="g8"
-         style="stroke-width:4.03224;stroke-dasharray:none" /></g><ellipse
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="ellipse17"
-       cx="190.71324"
-       cy="77.594887"
-       rx="5.9872503"
-       ry="6.2987328"
-       transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><path
-       style="fill:#8d1964;fill-opacity:1;stroke:#243264;stroke-width:3.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.76, 0.38;stroke-dashoffset:165.3;stroke-opacity:1"
-       d="m 227.85548,116.71003 -33.25961,0.0222"
-       id="path78"
-       sodipodi:nodetypes="cc" /><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="149.41658"
-       y="69.561821"
-       id="text31"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="149.41658"
-         y="69.561821"
-         id="tspan85">last/lastdb</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="108.32681"
-       y="55.208851"
-       id="text31-2"
-       transform="rotate(-0.07121325)"><tspan
-         id="tspan31-9"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="108.32681"
-         y="55.208851">seqtk/cutn</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="63.505283"
-       y="54.982609"
-       id="text31-23"
-       transform="matrix(0.99992946,0.00109076,0.01188048,1.0000835,0,0)"><tspan
-         id="tspan31-5"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="63.505283"
-         y="54.982609">assemblyscan</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="17.771902"
-       y="80.454239"
-       id="text31-7"><tspan
-         id="tspan31-6"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="17.771902"
-         y="80.454239">Target </tspan><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="17.771902"
-         y="86.627846"
-         id="tspan34" /></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="198.27255"
-       y="76.376396"
-       id="text31-4"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="198.27255"
-         y="76.376396"
-         id="tspan84">last/train</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="15.769502"
-       y="64.819618"
-       id="text31-7-4"><tspan
-         id="tspan31-6-1"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="15.769502"
-         y="64.819618">Queries</tspan></text><g
-       id="g3"
-       transform="matrix(0.12175883,0,0,-0.11466093,-23.311813,294.81977)"
-       style="stroke-width:3.78865"><path
-         id="path5862"
-         d="m 598.73267,1905.0888 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-         style="stroke-width:3.78865" /><text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.78865px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="513.65839"
-         y="-1872.9598"
-         id="text2"
-         transform="scale(1,-1)"><tspan
-           x="513.65839"
-           y="-1872.9598"
-           id="tspan2"
-           style="stroke-width:3.78865px"><tspan
-             x="513.65839"
-             y="-1872.9598"
-             style="font-size:32px;line-height:1.25;stroke-width:3.78865px"
-             id="tspan1">fasta</tspan></tspan></text><path
-         id="path6276-4"
-         d="m 524.39681,1938.4637 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-         style="fill:#ffffff;stroke-width:3.78865" /></g><g
-       id="g5"
-       transform="matrix(0.14146459,0,0,-0.12947065,-79.858757,311.91595)"
-       style="stroke-width:3.92686"><g
-         transform="matrix(0.8,0,0,0.8,440.29453,414.61207)"
-         id="g10541"
-         style="stroke-width:3.92686"><path
-           id="path10543"
-           d="m 598.73267,1905.0888 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-           style="stroke-width:3.92686" /><path
-           id="path10553"
-           d="m 524.39681,1938.4637 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-           style="fill:#ffffff;stroke-width:3.92686" /></g><g
-         id="g6322-2"
-         transform="matrix(0.8,0,0,0.8,431.33453,405.65209)"
-         style="stroke-width:3.92686"><path
-           d="m 598.73267,1905.0888 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-           id="path5862-6"
-           style="stroke-width:3.92686" /><text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.92686px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="513.77655"
-           y="-1873.8705"
-           id="text2-1"
-           transform="scale(1,-1)"><tspan
-             x="513.77655"
-             y="-1873.8705"
-             id="tspan2-6"
-             style="stroke-width:3.92686px"><tspan
-               x="513.77655"
-               y="-1873.8705"
-               style="font-size:32px;line-height:1.25;stroke-width:3.92686px"
-               id="tspan1-2">fasta</tspan></tspan></text><path
-           style="fill:#ffffff;stroke-width:3.92686"
-           d="m 524.39681,1938.4637 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-           id="path6276-4-8" /></g></g><g
-       id="layer1-9-8-6"
-       style="display:none;stroke-width:1.32402"
-       transform="matrix(0.02161556,0,0,0.02940703,56.012104,188.8181)"><g
-         id="g4340-6-5"
-         transform="matrix(1.0000013,0,0,1.0000013,-6.8781844e-5,-3.3646731e-4)"
-         style="stroke-width:1.32402"><path
-           d="m 84.33875,124.225 c 13.99,-3.1475 26.49625,-4.72125 37.51375,-4.72125 18.71125,0 32.7925,3.6725 42.23625,11.0175 9.44375,7.345 14.16625,19.4125 14.16625,36.2025 v 89.19375 h -39.08875 v -81.32375 c 0,-15.215 -8.57,-22.82375 -25.70875,-22.82375 -3.84875,0 -7.78375,0.43875 -11.80375,1.31125 -4.02625,0.8775 -7.17375,1.9275 -9.445,3.14875 v 99.6875 H 53.12125 V 134.45625 c 6.82,-3.6725 17.22375,-7.0825 31.2175,-10.23125"
-           id="path34-9-3"
-           style="fill:#22ae63;stroke-width:1.32402" /><path
-           d="m 222.85,153.0875 h -19.4125 v -29.90625 h 19.675 v -3.1475 c 0.1725,-19.9375 4.76375,-33.79625 13.7725,-41.58 9.005,-7.78 21.29,-11.67375 36.8575,-11.67375 2.795,0 5.8575,0.2625 9.1825,0.78625 3.32,0.525 6.03375,1.14 8.13125,1.83625 v 34.36625 c -1.92625,-1.9225 -3.84875,-3.365 -5.77125,-4.3275 -1.92625,-0.96 -4.37375,-1.44375 -7.345,-1.44375 -4.89875,0 -8.7475,1.3125 -11.5425,3.935 -2.79875,2.62375 -4.1975,7.08375 -4.1975,13.37875 v 7.87 h 28.85625 v 29.90625 h -29.1175 v 102.835 H 222.85 Z"
-           id="path38-4-1"
-           style="fill:#22ae63;stroke-width:1.32402" /><path
-           style="fill:#22af62;stroke-width:1.32402"
-           id="path40-7-8"
-           d="m 319.65,162 h 80.0125 v 27.02 H 319.65 Z" /><path
-           d="M 464.975,251.72375 C 454.48125,246.65375 446.1275,239 439.92125,228.77 c -6.21,-10.23125 -9.3125,-22.6925 -9.3125,-37.38375 0,-23.61 6.29625,-41.48875 18.8875,-53.6475 12.5925,-12.1525 29.3825,-18.23125 50.36875,-18.23125 7.345,0 14.77625,0.74625 22.29875,2.23 7.5175,1.4875 14.16625,3.54125 19.9375,6.165 v 33.57875 c -7.17375,-3.14875 -13.55625,-5.55 -19.15,-7.215 -5.6,-1.65875 -11.195,-2.49125 -16.79,-2.49125 -11.5425,0 -20.5525,2.84375 -27.02,8.525 -6.4725,5.68625 -9.7075,14.56 -9.7075,26.6275 0,13.46875 3.0175,23.4375 9.05125,29.90625 6.03375,6.4725 15.87125,9.70625 29.5125,9.70625 10.3175,0 21.77375,-3.49625 34.365,-10.49375 v 33.31625 c -6.295,3.325 -12.8125,5.81625 -19.54375,7.47625 -6.73375,1.66 -14.29625,2.4925 -22.69125,2.4925 -12.94375,0 -24.65875,-2.5375 -35.1525,-7.6075"
-           id="path44-6-5"
-           style="fill:#231f20;stroke-width:1.32402" /><path
-           d="m 651.2375,218.53875 c 4.89375,-6.73 7.345,-16.5675 7.345,-29.5125 0,-14.16625 -2.40625,-24.265 -7.215,-30.3 -4.81125,-6.0325 -12.11125,-9.05 -21.90375,-9.05 -10.145,0 -17.445,3.0175 -21.905,9.05 -4.46,6.035 -6.69,16.13375 -6.69,30.3 0,13.47 2.31625,23.43875 6.9525,29.90625 4.6325,6.4725 11.845,9.70625 21.6425,9.70625 9.615,0 16.875,-3.365 21.77375,-10.1 M 579.095,242.0175 c -11.19375,-11.89 -16.79,-29.5525 -16.79,-52.99125 0,-24.4825 5.55125,-42.32125 16.66,-53.51625 11.1025,-11.19 27.9375,-16.78875 50.49875,-16.78875 22.56125,0 39.52125,5.73 50.8925,17.1825 11.3675,11.45625 17.0525,29.16375 17.0525,53.1225 0,23.085 -5.8625,40.66125 -17.5775,52.72875 -11.71875,12.06875 -28.50875,18.10125 -50.3675,18.10125 -22.38875,0 -39.17875,-5.94375 -50.36875,-17.83875"
-           id="path48-8-0"
-           style="fill:#231f20;stroke-width:1.32402" /><path
-           d="m 724.425,137.0875 c 2.62375,-2.27125 7.21375,-4.80875 13.7725,-7.6075 6.55875,-2.79625 13.90375,-5.2025 22.035,-7.21375 8.1325,-2.00875 15.9575,-3.0175 23.48,-3.0175 14.51375,0 24.56875,2.18875 30.1675,6.55875 v 28.59375 C 806.88375,152.8275 796.82875,152.04 783.7125,152.04 c -8.2225,0 -14.95375,0.43875 -20.2,1.3125 V 255.925 H 724.425 Z"
-           id="path52-1-1"
-           style="fill:#231f20;stroke-width:1.32402" /><path
-           d="m 864.25,174.8625 h 49.05625 c -1.225,-9.44375 -3.7175,-16.17375 -7.47625,-20.2 -3.7625,-4.02 -9.31375,-6.0325 -16.65875,-6.0325 -13.99375,0 -22.2975,8.74625 -24.92125,26.2325 m 87.8825,24.92125 h -87.62 c 3.32,18.36375 15.64875,27.54625 36.98875,27.54625 6.46875,0 12.81,-0.91875 19.02,-2.755 6.205,-1.83625 12.80875,-4.23875 19.805,-7.21375 V 250.94 c -14.34125,5.9425 -30.43,8.91875 -48.26875,8.91875 -13.46875,0 -25.275,-2.755 -35.415,-8.26375 -10.145,-5.50875 -18.015,-13.42 -23.61125,-23.74 -5.59875,-10.3175 -8.39375,-22.47125 -8.39375,-36.465 0,-23.08625 5.72625,-40.965 17.18375,-53.6475 11.45125,-12.6775 27.76125,-19.02 48.92375,-19.02 41.44875,0 61.9125,27.02125 61.3875,81.06125"
-           id="path56-3-9"
-           style="fill:#231f20;stroke-width:1.32402" /><path
-           style="fill:url(#linearGradient4391-8-7);stroke-width:1.32402"
-           id="path60-8-5"
-           d="m 350.2125,162.0875 -26.875,26.98 h 76.25 v -26.98 z" /></g></g><rect
-       style="fill:#ffffff;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect918"
-       width="1.805621"
-       height="9.3641844"
-       x="54.3218"
-       y="59.007946"
-       ry="2.6458333"
-       rx="2.6458333" /><g
-       id="g6247"
-       transform="translate(-103.52484,66.964801)"><g
-         id="g122"
-         transform="translate(101.75504,-70.783684)"><g
-           id="g9-8"
-           transform="matrix(0.12947131,0,0,-0.11466093,165.88324,338.78951)"
-           style="stroke-width:4.06863"><path
-             id="path5862-69-1"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text2-7-4-7"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan2-4-6-2"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path6276-4-9-2"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g95"
-           transform="matrix(0.12947131,0,0,-0.11466093,164.8249,339.84785)"
-           style="stroke-width:4.06863"><path
-             id="path94"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="406.96188"
-             y="-1723.3799"
-             id="text94"
-             transform="scale(1,-1)"><tspan
-               x="406.96188"
-               y="-1723.3799"
-               id="tspan94"
-               style="font-size:27.538px;stroke-width:4.06863px">MAF</tspan></text><path
-             id="path95"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g></g><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="m 146.52424,169.99361 -0.0449,-128.2605"
-       id="path108"
-       sodipodi:nodetypes="cc" /><path
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64582;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="path112"
-       d="m 128.59929,63.688121 c -0.30091,-3.069895 -2.67029,-5.467208 -5.59752,-5.663506 -2.92722,-0.196301 -5.55072,1.866188 -6.19786,4.872507 -0.64713,3.006318 0.87257,6.071614 3.59033,8.017297 -2.7175,1.945682 -4.2372,5.010979 -3.59006,8.017297 0.64714,3.006318 3.27064,5.068807 6.19786,4.872506 2.92722,-0.196298 5.29661,-2.59361 5.59752,-5.663505 0.30091,-3.069893 -0.92596,-5.908806 -3.75586,-7.226298 2.82963,-1.317488 4.0565,-4.156402 3.75559,-7.226298 z"
-       sodipodi:nodetypes="ssscssscs" /><g
-       id="g1959"
-       transform="translate(49.925576,60.388917)"><g
-         id="g6809"><g
-           id="g6796"><g
-             id="g1947"
-             transform="matrix(0.12947131,0,0,-0.11466093,165.88324,338.78951)"
-             style="stroke-width:4.06863"><path
-               id="path1939"
-               d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-               style="stroke-width:4.06863" /><text
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2.42713;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:none;stroke-dashoffset:624.756;stroke-opacity:0.992157"
+         d="M 20.354762,52.341753 H 152.09497"
+         id="path1"
+         sodipodi:nodetypes="cc" />
+      <g
+         id="g155"
+         transform="matrix(1.2135653,0,0,1.2135653,22.940203,-60.983808)">
+        <rect
+           style="fill:#000000;stroke:#000000;stroke-width:0.953169;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+           id="rect151"
+           width="1.3235754"
+           height="6.8642335"
+           x="97.656471"
+           y="208.98734"
+           ry="0.66178769"
+           rx="0.66178769"
+           transform="matrix(0,1,1,0,0,0)" />
+        <g
+           id="g152"
+           transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+           style="stroke-width:2.97415;stroke-dasharray:none">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+             id="path151"
+             sodipodi:nodetypes="ccc" />
+        </g>
+        <g
+           id="g154"
+           transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+           style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+          <g
+             id="g153"
+             transform="translate(-68.54295,-4.5648763)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-               x="402.01187"
-               y="-1727.0454"
-               id="text1943"
-               transform="scale(1,-1)"><tspan
-                 x="402.01187"
-                 y="-1727.0454"
-                 id="tspan1941"
-                 style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-               id="path1945"
-               d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-               style="fill:#ffffff;stroke-width:4.06863" /></g><g
-             id="g1957"
-             transform="matrix(0.12947131,0,0,-0.11466093,164.8249,339.84785)"
-             style="stroke-width:4.06863"><path
-               id="path1949"
-               d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-               style="stroke-width:4.06863" /><text
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+               x="328.28516"
+               y="91.270317"
+               id="text152"><tspan
+                 sodipodi:role="line"
+                 id="tspan152"
+                 style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                 x="328.28516"
+                 y="91.270317">CRAM</tspan></text>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g147"
+         transform="matrix(1.2135653,0,0,1.2135653,-2.8712355,-55.497747)">
+        <rect
+           style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+           id="rect143"
+           width="1.2143828"
+           height="6.2979465"
+           x="-85.160133"
+           y="169.28697"
+           ry="0.60719138"
+           rx="0.60719138"
+           transform="matrix(0,1,1,0,39.983515,182.8712)" />
+        <g
+           id="g144"
+           transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+           style="stroke-width:2.97415;stroke-dasharray:none">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+             id="path143"
+             sodipodi:nodetypes="ccc" />
+        </g>
+        <g
+           id="g146"
+           transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+           style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+          <g
+             id="g145"
+             transform="translate(-68.54295,-4.5648763)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <text
                xml:space="preserve"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-               x="402.01187"
-               y="-1721.063"
-               id="text1953"
-               transform="scale(1,-1)"><tspan
-                 x="402.01187"
-                 y="-1721.063"
-                 id="tspan1951"
-                 style="font-size:27.538px;stroke-width:4.06863px"> …</tspan></text><path
-               id="path1955"
-               d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-               style="fill:#ffffff;stroke-width:4.06863" /></g></g></g><g
-         id="g6784"
-         transform="translate(0,-1.56441)"><g
-           id="g6466"
-           transform="matrix(0.12947131,0,0,-0.11466093,116.66391,340.35392)"
-           style="stroke-width:4.06863"><path
-             id="path6458"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6462"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6460"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path6464"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6476"
-           transform="matrix(0.12947131,0,0,-0.11466093,115.60557,341.41226)"
-           style="stroke-width:4.06863"><path
-             id="path6468"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="411.19073"
-             y="-1722.514"
-             id="text6472"
-             transform="scale(1,-1)"><tspan
-               x="411.19073"
-               y="-1722.514"
-               id="tspan6470"
-               style="font-size:27.538px;stroke-width:4.06863px">GFF</tspan></text><path
-             id="path6474"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g><g
-         id="g6772"
-         transform="translate(-1.3679867,-1.55151)"><g
-           id="g6486"
-           transform="matrix(0.12947131,0,0,-0.11466093,134.43834,340.34102)"
-           style="stroke-width:4.06863"><path
-             id="path6478"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6482"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6480"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path6484"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6496"
-           transform="matrix(0.12947131,0,0,-0.11466093,133.38,341.39936)"
-           style="stroke-width:4.06863"><path
-             id="path6488"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6492"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6490"
-               style="font-size:27.538px;stroke-width:4.06863px">BAM</tspan></text><path
-             id="path6494"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6755"
-           transform="matrix(0.12947131,0,0,-0.11466093,133.38,341.39936)"
-           style="stroke-width:4.06863"><path
-             id="path6747"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="405.98703"
-             y="-1722.6716"
-             id="text6751"
-             transform="scale(1,-1)"><tspan
-               x="405.98703"
-               y="-1722.6716"
-               id="tspan6749"
-               style="font-size:27.538px;stroke-width:4.06863px">BAM</tspan></text><path
-             id="path6753"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g><g
-         id="g6841"
-         transform="translate(15.038457,-1.55151)"><g
-           id="g6819"
-           transform="matrix(0.12947131,0,0,-0.11466093,134.43834,340.34102)"
-           style="stroke-width:4.06863"><path
-             id="path6811"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6815"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6813"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path6817"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6829"
-           transform="matrix(0.12947131,0,0,-0.11466093,133.38,341.39936)"
-           style="stroke-width:4.06863"><path
-             id="path6821"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6825"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6823"
-               style="font-size:27.538px;stroke-width:4.06863px">BAM</tspan></text><path
-             id="path6827"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6839"
-           transform="matrix(0.12947131,0,0,-0.11466093,133.38,341.39936)"
-           style="stroke-width:4.06863"><path
-             id="path6831"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="396.35275"
-             y="-1722.9965"
-             id="text6835"
-             transform="scale(1,-1)"><tspan
-               x="396.35275"
-               y="-1722.9965"
-               id="tspan6833"
-               style="font-size:27.538px;stroke-width:4.06863px">CRAM</tspan></text><path
-             id="path6837"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g></g><path
-       style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#240664;stroke-width:0.3;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:0.3, 1.8;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 57.645466,90.083323 57.600566,41.73311"
-       id="path4473"
-       sodipodi:nodetypes="cc" /><g
-       id="g1546"
-       transform="translate(-2.7185421e-6,-4.540324)"><ellipse
-         style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-         id="ellipse741"
-         cx="190.62587"
-         cy="101.68326"
-         rx="5.9872503"
-         ry="6.2987328"
-         transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><g
-         id="layer1-7"
-         transform="translate(-137.10499,11.913327)"><text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-           x="328.0383"
-           y="91.176842"
-           id="text3-90"><tspan
-             sodipodi:role="line"
-             id="tspan3-33"
-             style="font-size:4.23333px;line-height:1.16396px;stroke-width:0.529167"
-             x="328.0383"
-             y="91.176842">m2o</tspan></text></g></g><g
-       id="g981"
-       transform="translate(29.829741,-4.540324)"><ellipse
-         style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-         id="ellipse18"
-         cx="230.65625"
-         cy="101.68326"
-         rx="5.9872503"
-         ry="6.2987328"
-         transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><g
-         id="layer1-7-86"
-         transform="translate(-97.468873,13.239817)"><text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-           x="328.49396"
-           y="89.882103"
-           id="text3-90-2"><tspan
-             sodipodi:role="line"
-             id="tspan3-33-47"
-             style="font-size:4.23333px;line-height:1.16396px;stroke-width:0.529167"
-             x="328.49396"
-             y="89.882103">m2m</tspan></text></g></g><g
-       id="g6118"
-       transform="translate(0.50224568,-7.4588477)"><ellipse
-         style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-         id="ellipse24"
-         cx="190.04213"
-         cy="124.14982"
-         rx="5.9872503"
-         ry="6.2987328"
-         transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><text
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+               x="328.28516"
+               y="91.270317"
+               id="text144"><tspan
+                 sodipodi:role="line"
+                 id="tspan144"
+                 style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                 x="328.28516"
+                 y="91.270317">…</tspan></text>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g143"
+         transform="matrix(1.2135653,0,0,1.2135653,-2.8712355,-58.240777)">
+        <rect
+           style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+           id="rect140"
+           width="1.2143828"
+           height="6.2979465"
+           x="-85.160133"
+           y="169.28697"
+           ry="0.60719138"
+           rx="0.60719138"
+           transform="matrix(0,1,1,0,39.983515,182.8712)" />
+        <g
+           id="g140"
+           transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+           style="stroke-width:2.97415;stroke-dasharray:none">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+             id="path140"
+             sodipodi:nodetypes="ccc" />
+        </g>
+        <g
+           id="g142"
+           transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+           style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+          <g
+             id="g141"
+             transform="translate(-68.54295,-4.5648763)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+               x="328.28516"
+               y="91.270317"
+               id="text140"><tspan
+                 sodipodi:role="line"
+                 id="tspan140"
+                 style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                 x="328.28516"
+                 y="91.270317">BAM</tspan></text>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g137"
+         transform="matrix(1.2135653,0,0,1.2135653,-2.8712355,-60.983808)">
+        <rect
+           style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+           id="rect133"
+           width="1.2143828"
+           height="6.2979465"
+           x="-85.160133"
+           y="169.28697"
+           ry="0.60719138"
+           rx="0.60719138"
+           transform="matrix(0,1,1,0,39.983515,182.8712)" />
+        <g
+           id="g134"
+           transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+           style="stroke-width:2.97415;stroke-dasharray:none">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+             id="path134"
+             sodipodi:nodetypes="ccc" />
+        </g>
+        <g
+           id="g136"
+           transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+           style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+          <g
+             id="g135"
+             transform="translate(-68.54295,-4.5648763)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+               x="328.28516"
+               y="91.270317"
+               id="text134"><tspan
+                 sodipodi:role="line"
+                 id="tspan134"
+                 style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                 x="328.28516"
+                 y="91.270317">GFF</tspan></text>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g81"
+         transform="matrix(0.38689684,0,0,0.71682877,134.93169,12.693727)"
+         style="stroke:#233164;stroke-width:2.97415;stroke-dasharray:none;stroke-opacity:0.992157">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#233164;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+           d="m 46.404836,55.310006 54.019664,6.2e-4 h 75.29046"
+           id="path81"
+           sodipodi:nodetypes="ccc" />
+      </g>
+      <g
+         id="g82"
+         transform="matrix(0.82880875,0,0,0.71624217,155.96188,12.726165)"
+         style="fill:#000000;fill-opacity:0;stroke:#8d1964;stroke-width:2.97415;stroke-dasharray:none;stroke-opacity:1">
+        <path
+           style="fill:#000000;fill-opacity:0;stroke:#8d1964;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 57.686967,55.310006 42.737533,6.2e-4 h 49.71678"
+           id="path82"
+           sodipodi:nodetypes="ccc" />
+      </g>
+      <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-         x="186.70786"
-         y="119.51638"
-         id="text4485"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-           x="186.70786"
-           y="125.68999"
-           id="tspan4483" /></text><g
-         id="g1546-5"
-         transform="translate(-69.002898,38.944616)"><g
-           id="layer1-7-8"
-           transform="translate(-68.54295,-4.5648763)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-             x="328.0383"
-             y="91.176842"
-             id="text3-90-7"><tspan
-               sodipodi:role="line"
-               id="tspan3-33-9"
-               style="font-size:4.23333px;line-height:1.16396px;stroke-width:0.529167"
-               x="328.0383"
-               y="91.176842">o2o</tspan></text></g></g></g><g
-       id="g758"
-       transform="translate(17.566003,-20.43875)"><ellipse
-         style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-         id="ellipse25"
-         cx="214.51404"
-         cy="137.12981"
-         rx="5.9872503"
-         ry="6.2987328"
-         transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><g
-         id="layer1-7-1"
-         transform="translate(-113.08824,47.359643)"><text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-           x="328.0383"
-           y="91.176842"
-           id="text3-90-0"><tspan
-             sodipodi:role="line"
-             id="tspan3-33-4"
-             style="font-size:4.23333px;line-height:1.16396px;stroke-width:0.529167"
-             x="328.0383"
-             y="91.176842">m2o</tspan></text></g></g><g
-       id="g753"
-       transform="translate(40.746697,-19.762516)"><ellipse
-         style="fill:#ffffff;stroke:#666666;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-         id="ellipse22"
-         cx="247.89055"
-         cy="136.45357"
-         rx="5.9872503"
-         ry="6.2987328"
-         transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><g
-         id="layer1-7-2"
-         transform="translate(-78.487917,47.776592)"><text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-           x="326.93481"
-           y="90.083656"
-           id="text3-90-8"><tspan
-             sodipodi:role="line"
-             id="tspan3-33-3"
-             style="font-size:4.23333px;line-height:1.16396px;stroke-width:0.529167"
-             x="326.93481"
-             y="90.083656">o2m</tspan></text></g></g><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="149.60828"
-       y="118.26698"
-       id="text681"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="149.60828"
-         y="118.26698"
-         id="tspan679">last/split</tspan></text><path
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64582;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="path781"
-       d="m 88.083326,63.688121 c -0.30091,-3.069895 -2.67029,-5.467208 -5.59752,-5.663506 -2.92722,-0.196301 -5.55072,1.866188 -6.19786,4.872507 -0.64713,3.006318 0.87257,6.071614 3.59033,8.017297 -2.7175,1.945682 -4.2372,5.010979 -3.59006,8.017297 0.64714,3.006318 3.27064,5.068807 6.19786,4.872506 2.92722,-0.196298 5.29661,-2.59361 5.59752,-5.663505 0.30091,-3.069893 -0.92596,-5.908806 -3.75586,-7.226298 2.82963,-1.317488 4.0565,-4.156402 3.75559,-7.226298 z"
-       sodipodi:nodetypes="ssscssscs" /><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="138.99602"
-       y="180.34436"
-       id="text3937"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="138.99602"
-         y="180.34436"
-         id="tspan3935">last/mafconvert</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-       x="149.54478"
-       y="98.802628"
-       id="text6128"><tspan
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.93889px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-         x="149.54478"
-         y="98.802628"
-         id="tspan6126">last/lastal</tspan></text><g
-       id="g6404"
-       transform="translate(-103.60377,92.829652)"><g
-         id="g6402"
-         transform="translate(101.75504,-70.783684)"><g
-           id="g6390"
-           transform="matrix(0.12947131,0,0,-0.11466093,165.88324,338.78951)"
-           style="stroke-width:4.06863"><path
-             id="path6382"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text6386"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan6384"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path6388"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g6400"
-           transform="matrix(0.12947131,0,0,-0.11466093,164.8249,339.84785)"
-           style="stroke-width:4.06863"><path
-             id="path6392"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="410.18613"
-             y="-1722.8573"
-             id="text6396"
-             transform="scale(1,-1)"><tspan
-               x="410.18613"
-               y="-1722.8573"
-               id="tspan6394"
-               style="font-size:27.538px;stroke-width:4.06863px">PNG</tspan></text><path
-             id="path6398"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g></g><g
-       id="g7211"
-       transform="translate(-103.7127,29.548729)"><g
-         id="g7209"
-         transform="translate(101.75504,-70.783684)"><g
-           id="g7197"
-           transform="matrix(0.12947131,0,0,-0.11466093,165.88324,338.78951)"
-           style="stroke-width:4.06863"><path
-             id="path7189"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="402.01187"
-             y="-1727.0454"
-             id="text7193"
-             transform="scale(1,-1)"><tspan
-               x="402.01187"
-               y="-1727.0454"
-               id="tspan7191"
-               style="font-size:27.538px;stroke-width:4.06863px"> maf</tspan></text><path
-             id="path7195"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g><g
-           id="g7207"
-           transform="matrix(0.12947131,0,0,-0.11466093,164.8249,339.84785)"
-           style="stroke-width:4.06863"><path
-             id="path7199"
-             d="m 481.30947,1753.4644 h -2.51304 v 12.1255 c 0,0.076 -0.0119,0.1518 -0.0221,0.2284 -0.004,0.4815 -0.15713,0.9544 -0.48679,1.3291 l -20.17826,23.0502 c -0.006,0.01 -0.0118,0.01 -0.0161,0.014 -0.12027,0.1343 -0.2605,0.246 -0.4087,0.3427 -0.0439,0.029 -0.0882,0.054 -0.13415,0.08 -0.12844,0.07 -0.26468,0.1282 -0.40491,0.1702 -0.038,0.011 -0.0722,0.026 -0.1102,0.036 -0.15238,0.036 -0.31066,0.059 -0.47103,0.059 h -49.59068 c -2.26452,0 -4.10417,-1.8417 -4.10417,-4.1044 v -33.3298 h -2.51247 c -3.23944,0 -5.86611,-2.6255 -5.86611,-5.8661 v -30.5048 c 0,-3.2383 2.62667,-5.8655 5.86611,-5.8655 h 2.51266 v -20.8815 c 0,-2.2624 1.83965,-4.1043 4.10417,-4.1043 h 67.71875 c 2.26242,0 4.10417,1.8417 4.10417,4.1043 v 20.8815 h 2.51304 c 3.23849,0 5.86573,2.6272 5.86573,5.8655 v 30.5039 c -1.9e-4,3.2404 -2.62743,5.8661 -5.86592,5.8661 z m -74.33596,33.33 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="stroke-width:4.06863" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:27.538px;line-height:0.01%;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06863px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-             x="406.96188"
-             y="-1723.3799"
-             id="text7203"
-             transform="scale(1,-1)"><tspan
-               x="406.96188"
-               y="-1723.3799"
-               id="tspan7201"
-               style="font-size:27.538px;stroke-width:4.06863px">MAF</tspan></text><path
-             id="path7205"
-             d="m 406.97361,1786.8393 h 47.5386 v -20.9983 c 0,-1.1338 0.91983,-2.0521 2.05208,-2.0521 h 18.12807 v -10.2809 h -67.71875 z m 67.71894,-95.336 h -67.71894 v 19.7705 h 67.71875 v -19.7705 z"
-             style="fill:#ffffff;stroke-width:4.06863" /></g></g></g><ellipse
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="ellipse16"
-       cx="127.16214"
-       cy="148.66415"
-       rx="5.9872503"
-       ry="6.2987328"
-       transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><ellipse
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="ellipse16-1"
-       cx="127.33622"
-       cy="166.00153"
-       rx="5.9872503"
-       ry="6.2987328"
-       transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><text
-       xml:space="preserve"
-       transform="matrix(0.26458333,0,0,0.26458333,80.959933,-41.365006)"
-       id="text7814"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect7816);display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
-       x="0"
-       y="0"><tspan
-         x="59.416016"
-         y="710.89126"
-         id="tspan6"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan5">samtools
-</tspan></tspan><tspan
-         x="93.130859"
-         y="724.22457"
-         id="tspan8"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan7">/
-</tspan></tspan><tspan
-         x="73.865234"
-         y="737.55789"
-         id="tspan10"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan9">faidx</tspan></tspan></text><text
-       xml:space="preserve"
-       transform="matrix(0.26458333,0,0,0.26458333,80.959933,-24.027748)"
-       id="text7814-5"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect7816-5);display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
-       x="0"
-       y="0"><tspan
-         x="59.416016"
-         y="710.89126"
-         id="tspan12"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan11">samtools
-</tspan></tspan><tspan
-         x="93.130859"
-         y="724.22457"
-         id="tspan14"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan13">/
-</tspan></tspan><tspan
-         x="78.681641"
-         y="737.55789"
-         id="tspan16"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan15">dict</tspan></tspan></text><ellipse
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="ellipse9237"
-       cx="162.54279"
-       cy="77.594887"
-       rx="5.9872503"
-       ry="6.2987328"
-       transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><rect
-       style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect4032-6"
-       width="1.805621"
-       height="9.3641844"
-       x="-191.35692"
-       y="186.67242"
-       ry="2.6458333"
-       rx="2.6458333"
-       transform="rotate(-90)" /><rect
-       style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect9723"
-       width="1.805621"
-       height="9.3641844"
-       x="-191.35692"
-       y="228.25497"
-       ry="2.6458333"
-       rx="2.6458333"
-       transform="rotate(-90)" /><rect
-       style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect9725"
-       width="1.805621"
-       height="9.3641844"
-       x="-191.35692"
-       y="256.53235"
-       ry="2.6458333"
-       rx="2.6458333"
-       transform="rotate(-90)" /><rect
-       style="fill:#000000;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-       id="rect9727"
-       width="1.805621"
-       height="9.3641844"
-       x="-191.35692"
-       y="284.80972"
-       ry="2.6458333"
-       rx="2.6458333"
-       transform="rotate(-90)" /><g
-       id="g1133"
-       transform="translate(-4.9692057,-1.3032796)"><g
-         id="g861"
-         transform="translate(-7.735982,-20.424812)"><rect
-           style="fill:none;stroke:#000000;stroke-width:0.279098;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke markers fill;stop-color:#000000"
-           id="rect59928-8"
-           width="68.045471"
-           height="93.743568"
-           x="-103.0526"
-           y="122.47375"
-           transform="scale(-1,1)" /></g><g
-         id="g1088"
-         transform="translate(0.05609278,1.2281173)"><g
-           id="g918"
-           transform="translate(5.8313271,-17.998478)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="44.583557"
-             y="202.48405"
-             id="text31-7-4-1-27"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="44.583557"
-               y="202.48405"
-               id="tspan34-4-6-6">One-to-one</tspan></text><path
-             style="opacity:0.99;fill:none;fill-opacity:0;fill-rule:evenodd;stroke:#8d1964;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-             d="m 25.737305,201.07337 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path99-3-0-9" /></g><g
-           id="g117"
-           transform="translate(17.295273,31.234297)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="32.958553"
-             y="145.91557"
-             id="text31-7-4-1-5"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="32.958553"
-               y="145.91557"
-               id="tspan34-4-6-2">Many-to-one</tspan></text><path
-             style="opacity:0.99;fill:none;fill-opacity:0;fill-rule:evenodd;stroke:#243264;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-             d="m 14.273359,144.89522 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path99-3-0" /></g><g
-           id="g110"
-           transform="translate(-44.800627,7.6093415)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="95.215508"
-             y="129.43687"
-             id="text31-7-49-1"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="95.215508"
-               y="129.43687"
-               id="tspan34-5-1">Outputs</tspan></text><rect
-             style="fill:#1a1a1a;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-             id="rect918-1-2"
-             width="1.805621"
-             height="9.3641844"
-             x="81.193092"
-             y="123.7439"
-             ry="2.6458333"
-             rx="2.6458333" /></g><g
-           id="g109"
-           transform="translate(-7.765508,-6.0218172)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="58.04586"
-             y="129.43687"
-             id="text31-7-49-7"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="58.04586"
-               y="129.43687"
-               id="tspan34-5-6">modules </tspan></text><ellipse
-             style="fill:#ffffff;stroke:#000000;stroke-width:1.69701;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-             id="ellipse20-0"
-             cx="44.534821"
-             cy="128.42706"
-             rx="4.0804648"
-             ry="3.8020318"
-             transform="matrix(1,0,0.00409541,0.99999161,0,0)" /></g><g
-           id="g116"
-           transform="translate(17.295273,9.3791606)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="33.11961"
-             y="153.20161"
-             id="text31-7-4-1-15"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="33.11961"
-               y="153.20161"
-               id="tspan34-4-6-7">One-to-many</tspan></text><path
-             style="opacity:0.99;fill:#000000;fill-opacity:0.294821;fill-rule:evenodd;stroke:#f697f4;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.564706;paint-order:markers fill stroke"
-             d="m 14.273359,152.1519 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path99-3" /></g><g
-           id="g120"
-           transform="translate(17.295273,-19.914339)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="33.337513"
-             y="175.15941"
-             id="text31-7-4-1-9"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="33.337513"
-               y="175.15941"
-               id="tspan34-4-6-9">Target genome</tspan></text><path
-             style="opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#7eb2dd;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-             d="m 14.273359,174.14948 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path100" /></g><g
-           id="g119"
-           transform="translate(17.295273,-19.929831)"><path
-             style="opacity:0.99;fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-             d="m 14.273359,166.81695 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path99" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="33.11961"
-             y="167.89035"
-             id="text31-7-4-1"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="33.11961"
-               y="167.89035"
-               id="tspan34-4-6">Query genome(s)</tspan></text></g><g
-           id="g108"
-           transform="translate(22.895965,-19.652984)"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="27.355965"
-             y="129.43687"
-             id="text31-7-49"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="27.355965"
-               y="129.43687"
-               id="tspan34-5">Inputs</tspan></text><rect
-             style="fill:#ffffff;stroke:#000000;stroke-width:1.30031;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
-             id="rect918-1"
-             width="1.805621"
-             height="9.3641844"
-             x="13.496497"
-             y="123.7439"
-             ry="2.6458333"
-             rx="2.6458333" /></g><g
-           id="g115"
-           transform="translate(17.295273,9.3605471)"><path
-             style="opacity:0.99;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#24b064;stroke-width:1.546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
-             d="m 14.273359,159.48442 c 3.817768,0 7.63552,0 11.453282,0"
-             id="path99-1" /><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="33.223125"
-             y="160.50478"
-             id="text31-7-4-1-2-9"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="33.223125"
-               y="160.50478"
-               id="tspan34-4-6-3-5">Many-to-many</tspan></text></g><g
-           id="g974"><text
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
-             x="44.583557"
-             y="209.47653"
-             id="text31-7-4-1-27-6"
-             transform="translate(5.8313271,-18.339272)"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.88056px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
-               x="44.583557"
-               y="209.47653"
-               id="tspan34-4-6-6-7">Optional / Alternative</tspan></text><path
-             style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.3786;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.475719, 0.23786;stroke-dashoffset:103.469;stroke-opacity:1"
-             d="m 43.736867,190.05545 -12.883188,0.0225"
-             id="path78-3"
-             sodipodi:nodetypes="cc" /></g></g></g><g
-       id="g1"
-       transform="matrix(0.05915613,0,0,0.05915613,223.60373,39.570574)"><g
-         id="layer2"
-         style="display:inline"
-         transform="translate(87.061638)"><g
-           id="g4209"><path
-             id="path24"
-             d="m 1084.1,163.75 v 3.6 c -0.1,0 -0.1,0 -0.2,0.1 l -1.8,-1.5 c -4,-3.4 -8.3,-6.4 -13.1,-8.8 -0.8,-0.4 -1.6,-0.9 -2.5,-1.1 -0.1,-0.1 -0.2,-0.2 -0.3,-0.2 -1.8,-0.7 -3.6,-1.3 -5.5,-1.8 -4.1,-0.9 -8.2,-1 -12.3,-0.2 -5.3,1.1 -10,3.4 -14.5,6.4 -4.4,3 -8.4,6.5 -12.1,10.2 -0.7,0.7 -0.7,0.7 -1.1,-0.2 -2,-4.1 -4.2,-8.1 -6.9,-11.8 -2.1,-2.8 -4.4,-5.4 -7.4,-7.2 -3,-1.9 -6.3,-2.6 -9.8,-1.7 -4.3,1 -7.8,3.6 -11.1,6.4 -2,1.5 -3.8,3.3 -5.6,5 -1.7,1.5 -3.3,3 -5,4.5 -0.3,0.3 -0.5,0.3 -0.8,0 -1.7,-1.8 -3.5,-3.4 -5.6,-4.5 -3.1,-1.7 -6.3,-1.9 -9.6,-0.8 -2.8,0.9 -5.2,2.4 -7.7,4 -1,0.6 -1.9,1.3 -2.9,1.8 v -0.2 c 0.1,-0.2 0.1,-0.4 0.1,-0.6 0.2,-4.4 0.5,-8.9 1.2,-13.3 1,-6.1 2.5,-12 5.2,-17.5 2,-4.1 4.7,-7.9 8.1,-11 4.5,-4.1 9.8,-6.7 15.6,-8.3 6.3,-1.8 12.7,-2.6 19.2,-2.9 2.6,-0.1 5.1,-0.2 7.7,-0.3 1.3,0.5 2.6,0.8 3.9,1.2 1.9,0.6 3.8,1.2 5.7,1.7 1,0.4 1.9,0.7 2.9,1.1 3.7,1.3 7.3,3 10.4,5.5 0.8,0.6 1.6,1.3 2.4,2 -0.2,-0.6 -0.4,-1.1 -0.6,-1.7 -1.4,-3.7 -3.5,-6.7 -6.9,-8.8 -1.4,-0.9 -2.9,-1.5 -4.4,-2.3 0.1,0 0.3,0 0.4,-0.1 4.5,-0.8 9.1,-1.2 13.7,-1.4 3.9,-0.2 7.9,-0.1 11.8,0.3 4.6,0.5 9.1,1.4 13.4,3 6.4,2.4 11.9,6.1 16.2,11.5 3.7,4.7 6.1,10.1 7.6,15.9 1.5,5.7 2.1,11.6 2.3,17.5 -0.1,2.1 -0.1,4.3 -0.1,6.5"
-             class="st0"
-             style="fill:#24af63" /><path
-             id="path26"
-             d="m 1084.1,157.15 h 0.1 v 6.6 h -0.1 z"
-             class="st4"
-             style="fill:#ecdc86" /><path
-             id="path28"
-             d="m 1047.6,62.25 v 0.1 h -4.5 v -0.1 z"
-             style="fill:#a0918f" /><path
-             id="path30"
-             d="m 1050.5,250.65 c 2.5,-1 4.9,-2.3 7.3,-3.6 2.8,-1.7 5.4,-3.5 8,-5.4 2.2,-1.6 4.3,-3.3 6.4,-5.1 l 3.6,-3 c 0.2,-0.2 0.2,-0.1 0.3,0.1 0.4,1.6 0.7,3.3 1.1,5 0.5,2.3 0.8,4.6 1.1,6.9 0.3,2.7 0.4,5.3 0.2,8 -0.2,3.3 -0.8,6.6 -2,9.7 q -1.05,2.85 -2.7,5.4 c -1.4,2.2 -3,4.2 -5,5.9 -2.3,2.1 -4.9,3.9 -7.7,5.4 -3.7,2.1 -7.7,3.6 -11.8,4.8 -3.9,1.2 -7.9,2 -11.9,2.7 -1.1,0.2 -2.2,0.4 -3.3,0.4 -2.3,-0.1 -4.6,-0.6 -6.8,-1.4 -3.3,-1.3 -6.2,-3.3 -9.5,-4.8 -1.8,-0.8 -3.6,-1.4 -5.5,-1.5 -2.5,-0.2 -4.6,0.7 -6.4,2.4 l -3.9,3.9 c -2.2,2.2 -4.8,3.7 -7.9,4.2 -2.1,0.3 -4.1,0.2 -6.2,-0.1 -2.9,-0.4 -5.7,-1.1 -8.4,-1.9 -4,-1.3 -7.7,-3.1 -11.1,-5.7 -3.2,-2.4 -5.7,-5.4 -7.8,-8.8 -2.1,-3.5 -3.3,-7.2 -4.2,-11.1 -0.4,-1.7 -0.6,-3.5 -0.8,-5.2 -0.3,-2.5 -0.4,-4.9 -0.3,-7.4 0.1,-3.5 0.4,-6.9 0.9,-10.4 0.4,0.4 0.8,0.7 1.1,1 2.2,2 4.7,3.8 7.3,5.4 2.9,1.7 6.1,3.1 9.4,4 2.2,0.6 4.5,1 6.8,1.1 1.9,0.2 3.8,0.2 5.7,0.1 2.2,-0.1 4.5,-0.3 6.7,-0.9 0.3,0 0.6,0 0.8,-0.1 q 3,-0.6 6,-1.5 c 2.3,-0.7 4.5,-1.4 6.7,-2.2 2.1,-0.8 4.3,-1.7 6.4,-2.6 0.6,-0.3 1,-0.2 1.5,0.2 3.5,2.7 7.3,5 11.4,6.7 4.6,1.8 9.3,2.7 14.2,2.3 3.6,-0.7 7,-1.6 10.3,-2.9"
-             class="st0"
-             style="fill:#24af63" /><path
-             id="path32"
-             d="m 1050.5,250.65 c -3.3,1.3 -6.7,2.2 -10.2,2.5 -4.9,0.4 -9.6,-0.5 -14.2,-2.3 -4.1,-1.6 -7.9,-3.9 -11.4,-6.7 -0.5,-0.4 -0.9,-0.5 -1.5,-0.2 -2.1,0.9 -4.2,1.8 -6.4,2.6 -2.2,0.8 -4.4,1.6 -6.7,2.2 -2,0.6 -4,1 -6,1.5 -0.3,0.1 -0.6,0.1 -0.8,0.1 l 2.1,-2.4 c 2.8,-3.2 4.8,-6.9 5.9,-11.1 1.6,-5.6 3.2,-11.3 4.6,-17 1,-4.2 1.8,-8.4 2.4,-12.7 0.4,-3.1 1,-14.9 0.8,-17.7 -0.5,-8.6 -2.4,-16.8 -5.9,-24.7 -2.1,-4.7 -5.7,-7.9 -10.7,-9.2 -2.2,-0.6 -4.4,-0.4 -6.5,0.3 -0.2,0.1 -0.3,0.2 -0.5,0.1 3.3,-2.8 6.7,-5.4 11.1,-6.4 3.5,-0.8 6.8,-0.2 9.8,1.7 3,1.9 5.3,4.4 7.4,7.2 2.7,3.7 4.9,7.7 6.9,11.8 0.4,0.9 0.4,0.9 1.1,0.2 3.7,-3.8 7.7,-7.3 12.1,-10.2 4.4,-3 9.2,-5.3 14.5,-6.4 4.1,-0.8 8.2,-0.7 12.3,0.2 1.9,0.4 3.7,1 5.5,1.8 0.1,0.1 0.3,0.1 0.3,0.2 -5.3,0.1 -9.8,2.1 -13.9,5.2 -2,1.5 -3.8,3.2 -5.2,5.3 -1.1,1.7 -2.1,3.6 -2.9,5.5 -1.8,3.8 -3.3,7.8 -4.4,11.9 -0.9,3.5 -1.5,7.1 -1.8,10.7 -0.2,2.8 -0.3,5.6 -0.2,8.4 0.1,3.4 0.5,6.8 0.9,10.3 0.7,5.7 1.7,11.4 2.7,17.1 0.5,3.1 0.9,6.3 1.5,9.5 0.7,4.6 3.3,8 7,10.6 0,-0.1 0.2,0 0.3,0.1"
-             class="st4"
-             style="fill:#ecdc86" /><path
-             id="path34"
-             d="m 1043.1,62.35 h 4.5 c 3.6,0.2 7.2,0.8 10.6,2 2.7,0.9 3.3,2.7 1.7,5 -1.1,1.6 -2.7,2.8 -4.4,3.9 -2.1,1.4 -4.4,2.6 -6.9,3.5 -2.5,1 -4.9,0 -6.5,-2.5 -0.5,-0.8 -0.9,-1.6 -1.1,-2.5 -0.1,-0.3 -0.2,-0.4 -0.5,-0.4 -5.6,-1 -10.6,0.3 -14.7,4.3 -3.4,3.2 -5.4,7.3 -6.8,11.7 -1.3,4 -1.9,8 -2.1,12.2 -0.2,3.7 0.1,7.4 0.6,11 0.1,0.6 0.3,1.2 0.3,1.9 0.1,0.8 -0.2,1.5 -0.8,1.9 -0.7,0.5 -1.5,0.4 -2.3,0.4 -1.9,-0.6 -3.8,-1.2 -5.7,-1.7 v -1.3 c 0,-2 0,-3.9 0.1,-5.9 0.4,-7.7 1.6,-15.3 4.6,-22.5 2.2,-5.4 5.4,-10.1 9.9,-13.8 3.7,-3.1 7.9,-5.1 12.6,-6.2 2.4,-0.6 4.6,-0.9 6.9,-1"
-             style="fill:#3f2b29" /><path
-             id="path36"
-             d="m 1014.8,114.65 c 0.8,0 1.6,0.1 2.3,-0.4 0.7,-0.5 0.9,-1.2 0.8,-1.9 -0.1,-0.6 -0.2,-1.3 -0.3,-1.9 0.4,0 0.7,-0.1 1.1,-0.1 1.4,0.8 2.9,1.5 4.4,2.3 3.4,2.1 5.5,5.1 6.9,8.8 0.2,0.6 0.4,1.1 0.6,1.7 -0.8,-0.7 -1.6,-1.4 -2.4,-2 -3.2,-2.4 -6.7,-4.1 -10.4,-5.5 -1.1,-0.3 -2,-0.6 -3,-1"
-             class="st7"
-             style="fill:#396e35" /><path
-             id="path38"
-             d="m 1009.1,111.65 v 1.3 c -1.3,-0.4 -2.6,-0.7 -3.9,-1.2 1.4,-0.1 2.7,-0.1 3.9,-0.1"
-             class="st7"
-             style="fill:#396e35" /></g></g><g
-         id="layer3"
-         style="display:inline"
-         transform="translate(5.376)"><text
-           id="text53"
-           x="48.898998"
-           y="241.245"
-           font-size="209.87"
-           font-weight="bold"
-           style="font-weight:700;font-size:209.87px;font-family:'Maven Pro'"><tspan
-             id="tspan55"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:14.8189;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="194.647"
+         y="129.12462"
+         id="text677"
+         transform="matrix(1.2135653,0,0,1.2135653,-7.0477946,-113.83172)"><tspan
+           x="194.647"
+           y="129.12462"
+           id="tspan21"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan20">last/</tspan>
+</tspan><tspan
+           x="194.647"
+           y="132.94825"
+           id="tspan28"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan22">dotplot</tspan></tspan></text>
+      <rect
+         style="fill:#ffffff;stroke:#000000;stroke-width:0.931504;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+         id="rect918-0"
+         width="1.2934933"
+         height="6.7082238"
+         x="18.643305"
+         y="49.217205"
+         ry="1.8953964"
+         rx="1.8953964" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:11.0575;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="100.31182"
+         y="86.349396"
+         id="text31"
+         transform="matrix(1.2135653,0,0,1.2135653,-21.336147,-61.578264)"><tspan
+           x="100.31182"
+           y="86.349396"
+           id="tspan32"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan29">last/</tspan>
+</tspan><tspan
+           x="100.31182"
+           y="90.173028"
+           id="tspan38"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan35">lastdb</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:12.0192;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="76.481003"
+         y="77.884949"
+         id="text31-2"
+         transform="matrix(1.2135644,-0.00150835,0.00150835,1.2135644,-18.235469,-51.199998)"><tspan
+           x="76.481003"
+           y="77.884949"
+           id="tspan40"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan39">seqtk/</tspan>
+</tspan><tspan
+           x="76.481003"
+           y="81.708581"
+           id="tspan52"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan41">cutn</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.53808px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.947701;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="3.5376234"
+         y="54.05056"
+         id="text31-7"><tspan
+           id="tspan31-6"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.53808px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.947701"
+           x="3.5376234"
+           y="54.05056">Target </tspan><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.53808px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.947701"
+           x="3.5376234"
+           y="58.473141"
+           id="tspan34" /></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:10.6195;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="117.15866"
+         y="77.539764"
+         id="text31-4"
+         transform="matrix(1.2135653,0,0,1.2135653,-16.307927,-50.8872)"><tspan
+           x="117.15866"
+           y="77.539764"
+           id="tspan54"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan53">last/</tspan>
+</tspan><tspan
+           x="117.15866"
+           y="81.363396"
+           id="tspan57"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan56">train</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.53808px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.947701;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="3.2269731"
+         y="59.290783"
+         id="text31-7-4"><tspan
+           id="tspan31-6-1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.53808px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.947701"
+           x="3.2269731"
+           y="59.290783">Queries</tspan></text>
+      <rect
+         style="fill:#ffffff;stroke:#000000;stroke-width:0.931504;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+         id="rect918"
+         width="1.2934933"
+         height="6.7082238"
+         x="29.720884"
+         y="54.164223"
+         ry="1.8953964"
+         rx="1.8953964" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:13.0064;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="169.12553"
+         y="108.55206"
+         id="text681"
+         transform="matrix(1.2135653,0,0,1.2135653,-2.092811,-88.865574)"><tspan
+           x="169.12553"
+           y="108.55206"
+           id="tspan59"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan58">last/</tspan>
+</tspan><tspan
+           x="169.12553"
+           y="112.3757"
+           id="tspan62"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan60">split</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:19.5433;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="200.36678"
+         y="108.52708"
+         id="text3937"
+         transform="matrix(1.2135653,0,0,1.2135653,11.834462,-88.492329)"><tspan
+           x="200.36678"
+           y="108.52708"
+           id="tspan64"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan63">last/</tspan>
+</tspan><tspan
+           x="200.36678"
+           y="112.35071"
+           id="tspan66"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan65">mafconvert</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:12.2655;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="155.99557"
+         y="106.41664"
+         id="text6128"
+         transform="matrix(1.2135653,0,0,1.2135653,-37.609791,-85.931177)"><tspan
+           x="155.99557"
+           y="106.41664"
+           id="tspan68"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan67">last/</tspan>
+</tspan><tspan
+           x="155.99557"
+           y="110.24027"
+           id="tspan70"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan69">lastal</tspan></tspan></text>
+      <g
+         id="g2"
+         transform="matrix(0.0423777,0,0,0.0423777,4.7318095,3.0575359)">
+        <g
+           id="layer2"
+           style="display:inline"
+           transform="translate(87.061638)">
+          <g
+             id="g4209">
+            <path
+               id="path24"
+               d="m 1084.1,163.75 v 3.6 c -0.1,0 -0.1,0 -0.2,0.1 l -1.8,-1.5 c -4,-3.4 -8.3,-6.4 -13.1,-8.8 -0.8,-0.4 -1.6,-0.9 -2.5,-1.1 -0.1,-0.1 -0.2,-0.2 -0.3,-0.2 -1.8,-0.7 -3.6,-1.3 -5.5,-1.8 -4.1,-0.9 -8.2,-1 -12.3,-0.2 -5.3,1.1 -10,3.4 -14.5,6.4 -4.4,3 -8.4,6.5 -12.1,10.2 -0.7,0.7 -0.7,0.7 -1.1,-0.2 -2,-4.1 -4.2,-8.1 -6.9,-11.8 -2.1,-2.8 -4.4,-5.4 -7.4,-7.2 -3,-1.9 -6.3,-2.6 -9.8,-1.7 -4.3,1 -7.8,3.6 -11.1,6.4 -2,1.5 -3.8,3.3 -5.6,5 -1.7,1.5 -3.3,3 -5,4.5 -0.3,0.3 -0.5,0.3 -0.8,0 -1.7,-1.8 -3.5,-3.4 -5.6,-4.5 -3.1,-1.7 -6.3,-1.9 -9.6,-0.8 -2.8,0.9 -5.2,2.4 -7.7,4 -1,0.6 -1.9,1.3 -2.9,1.8 v -0.2 c 0.1,-0.2 0.1,-0.4 0.1,-0.6 0.2,-4.4 0.5,-8.9 1.2,-13.3 1,-6.1 2.5,-12 5.2,-17.5 2,-4.1 4.7,-7.9 8.1,-11 4.5,-4.1 9.8,-6.7 15.6,-8.3 6.3,-1.8 12.7,-2.6 19.2,-2.9 2.6,-0.1 5.1,-0.2 7.7,-0.3 1.3,0.5 2.6,0.8 3.9,1.2 1.9,0.6 3.8,1.2 5.7,1.7 1,0.4 1.9,0.7 2.9,1.1 3.7,1.3 7.3,3 10.4,5.5 0.8,0.6 1.6,1.3 2.4,2 -0.2,-0.6 -0.4,-1.1 -0.6,-1.7 -1.4,-3.7 -3.5,-6.7 -6.9,-8.8 -1.4,-0.9 -2.9,-1.5 -4.4,-2.3 0.1,0 0.3,0 0.4,-0.1 4.5,-0.8 9.1,-1.2 13.7,-1.4 3.9,-0.2 7.9,-0.1 11.8,0.3 4.6,0.5 9.1,1.4 13.4,3 6.4,2.4 11.9,6.1 16.2,11.5 3.7,4.7 6.1,10.1 7.6,15.9 1.5,5.7 2.1,11.6 2.3,17.5 -0.1,2.1 -0.1,4.3 -0.1,6.5"
+               class="st0"
+               style="fill:#24af63" />
+            <path
+               id="path26"
+               d="m 1084.1,157.15 h 0.1 v 6.6 h -0.1 z"
+               class="st4"
+               style="fill:#ecdc86" />
+            <path
+               id="path28"
+               d="m 1047.6,62.25 v 0.1 h -4.5 v -0.1 z"
+               style="fill:#a0918f" />
+            <path
+               id="path30"
+               d="m 1050.5,250.65 c 2.5,-1 4.9,-2.3 7.3,-3.6 2.8,-1.7 5.4,-3.5 8,-5.4 2.2,-1.6 4.3,-3.3 6.4,-5.1 l 3.6,-3 c 0.2,-0.2 0.2,-0.1 0.3,0.1 0.4,1.6 0.7,3.3 1.1,5 0.5,2.3 0.8,4.6 1.1,6.9 0.3,2.7 0.4,5.3 0.2,8 -0.2,3.3 -0.8,6.6 -2,9.7 q -1.05,2.85 -2.7,5.4 c -1.4,2.2 -3,4.2 -5,5.9 -2.3,2.1 -4.9,3.9 -7.7,5.4 -3.7,2.1 -7.7,3.6 -11.8,4.8 -3.9,1.2 -7.9,2 -11.9,2.7 -1.1,0.2 -2.2,0.4 -3.3,0.4 -2.3,-0.1 -4.6,-0.6 -6.8,-1.4 -3.3,-1.3 -6.2,-3.3 -9.5,-4.8 -1.8,-0.8 -3.6,-1.4 -5.5,-1.5 -2.5,-0.2 -4.6,0.7 -6.4,2.4 l -3.9,3.9 c -2.2,2.2 -4.8,3.7 -7.9,4.2 -2.1,0.3 -4.1,0.2 -6.2,-0.1 -2.9,-0.4 -5.7,-1.1 -8.4,-1.9 -4,-1.3 -7.7,-3.1 -11.1,-5.7 -3.2,-2.4 -5.7,-5.4 -7.8,-8.8 -2.1,-3.5 -3.3,-7.2 -4.2,-11.1 -0.4,-1.7 -0.6,-3.5 -0.8,-5.2 -0.3,-2.5 -0.4,-4.9 -0.3,-7.4 0.1,-3.5 0.4,-6.9 0.9,-10.4 0.4,0.4 0.8,0.7 1.1,1 2.2,2 4.7,3.8 7.3,5.4 2.9,1.7 6.1,3.1 9.4,4 2.2,0.6 4.5,1 6.8,1.1 1.9,0.2 3.8,0.2 5.7,0.1 2.2,-0.1 4.5,-0.3 6.7,-0.9 0.3,0 0.6,0 0.8,-0.1 q 3,-0.6 6,-1.5 c 2.3,-0.7 4.5,-1.4 6.7,-2.2 2.1,-0.8 4.3,-1.7 6.4,-2.6 0.6,-0.3 1,-0.2 1.5,0.2 3.5,2.7 7.3,5 11.4,6.7 4.6,1.8 9.3,2.7 14.2,2.3 3.6,-0.7 7,-1.6 10.3,-2.9"
+               class="st0"
+               style="fill:#24af63" />
+            <path
+               id="path32"
+               d="m 1050.5,250.65 c -3.3,1.3 -6.7,2.2 -10.2,2.5 -4.9,0.4 -9.6,-0.5 -14.2,-2.3 -4.1,-1.6 -7.9,-3.9 -11.4,-6.7 -0.5,-0.4 -0.9,-0.5 -1.5,-0.2 -2.1,0.9 -4.2,1.8 -6.4,2.6 -2.2,0.8 -4.4,1.6 -6.7,2.2 -2,0.6 -4,1 -6,1.5 -0.3,0.1 -0.6,0.1 -0.8,0.1 l 2.1,-2.4 c 2.8,-3.2 4.8,-6.9 5.9,-11.1 1.6,-5.6 3.2,-11.3 4.6,-17 1,-4.2 1.8,-8.4 2.4,-12.7 0.4,-3.1 1,-14.9 0.8,-17.7 -0.5,-8.6 -2.4,-16.8 -5.9,-24.7 -2.1,-4.7 -5.7,-7.9 -10.7,-9.2 -2.2,-0.6 -4.4,-0.4 -6.5,0.3 -0.2,0.1 -0.3,0.2 -0.5,0.1 3.3,-2.8 6.7,-5.4 11.1,-6.4 3.5,-0.8 6.8,-0.2 9.8,1.7 3,1.9 5.3,4.4 7.4,7.2 2.7,3.7 4.9,7.7 6.9,11.8 0.4,0.9 0.4,0.9 1.1,0.2 3.7,-3.8 7.7,-7.3 12.1,-10.2 4.4,-3 9.2,-5.3 14.5,-6.4 4.1,-0.8 8.2,-0.7 12.3,0.2 1.9,0.4 3.7,1 5.5,1.8 0.1,0.1 0.3,0.1 0.3,0.2 -5.3,0.1 -9.8,2.1 -13.9,5.2 -2,1.5 -3.8,3.2 -5.2,5.3 -1.1,1.7 -2.1,3.6 -2.9,5.5 -1.8,3.8 -3.3,7.8 -4.4,11.9 -0.9,3.5 -1.5,7.1 -1.8,10.7 -0.2,2.8 -0.3,5.6 -0.2,8.4 0.1,3.4 0.5,6.8 0.9,10.3 0.7,5.7 1.7,11.4 2.7,17.1 0.5,3.1 0.9,6.3 1.5,9.5 0.7,4.6 3.3,8 7,10.6 0,-0.1 0.2,0 0.3,0.1"
+               class="st4"
+               style="fill:#ecdc86" />
+            <path
+               id="path34"
+               d="m 1043.1,62.35 h 4.5 c 3.6,0.2 7.2,0.8 10.6,2 2.7,0.9 3.3,2.7 1.7,5 -1.1,1.6 -2.7,2.8 -4.4,3.9 -2.1,1.4 -4.4,2.6 -6.9,3.5 -2.5,1 -4.9,0 -6.5,-2.5 -0.5,-0.8 -0.9,-1.6 -1.1,-2.5 -0.1,-0.3 -0.2,-0.4 -0.5,-0.4 -5.6,-1 -10.6,0.3 -14.7,4.3 -3.4,3.2 -5.4,7.3 -6.8,11.7 -1.3,4 -1.9,8 -2.1,12.2 -0.2,3.7 0.1,7.4 0.6,11 0.1,0.6 0.3,1.2 0.3,1.9 0.1,0.8 -0.2,1.5 -0.8,1.9 -0.7,0.5 -1.5,0.4 -2.3,0.4 -1.9,-0.6 -3.8,-1.2 -5.7,-1.7 v -1.3 c 0,-2 0,-3.9 0.1,-5.9 0.4,-7.7 1.6,-15.3 4.6,-22.5 2.2,-5.4 5.4,-10.1 9.9,-13.8 3.7,-3.1 7.9,-5.1 12.6,-6.2 2.4,-0.6 4.6,-0.9 6.9,-1"
+               style="fill:#3f2b29" />
+            <path
+               id="path36"
+               d="m 1014.8,114.65 c 0.8,0 1.6,0.1 2.3,-0.4 0.7,-0.5 0.9,-1.2 0.8,-1.9 -0.1,-0.6 -0.2,-1.3 -0.3,-1.9 0.4,0 0.7,-0.1 1.1,-0.1 1.4,0.8 2.9,1.5 4.4,2.3 3.4,2.1 5.5,5.1 6.9,8.8 0.2,0.6 0.4,1.1 0.6,1.7 -0.8,-0.7 -1.6,-1.4 -2.4,-2 -3.2,-2.4 -6.7,-4.1 -10.4,-5.5 -1.1,-0.3 -2,-0.6 -3,-1"
+               class="st7"
+               style="fill:#396e35" />
+            <path
+               id="path38"
+               d="m 1009.1,111.65 v 1.3 c -1.3,-0.4 -2.6,-0.7 -3.9,-1.2 1.4,-0.1 2.7,-0.1 3.9,-0.1"
+               class="st7"
+               style="fill:#396e35" />
+          </g>
+        </g>
+        <g
+           id="layer3"
+           style="display:inline"
+           transform="translate(5.376)">
+          <text
+             id="text53"
              x="48.898998"
              y="241.245"
-             class="st0 st1 st2"
              font-size="209.87"
              font-weight="bold"
-             style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#24af63">nf-</tspan></text><text
-           id="text69"
-           x="357.14099"
-           y="241.245"
-           font-size="209.87"
-           font-weight="bold"
-           style="font-weight:700;font-size:209.87px;font-family:'Maven Pro'"><tspan
-             id="tspan71"
+             style="font-weight:700;font-size:209.87px;font-family:'Maven Pro'"><tspan
+               id="tspan55"
+               x="48.898998"
+               y="241.245"
+               class="st0 st1 st2"
+               font-size="209.87"
+               font-weight="bold"
+               style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#24af63">nf-</tspan></text>
+          <text
+             id="text69"
              x="357.14099"
              y="241.245"
-             class="st0 st1 st2"
              font-size="209.87"
              font-weight="bold"
-             style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#24af63"><tspan
-               id="tspan73"
-               style="fill:#050505">core/</tspan></tspan></text><text
-           id="text59"
-           x="-260.04999"
-           y="457.04501"
-           font-weight="bold"
-           style="font-weight:700;font-family:'Maven Pro'"><tspan
-             id="tspan61"
-             x="47.849998"
+             style="font-weight:700;font-size:209.87px;font-family:'Maven Pro'"><tspan
+               id="tspan71"
+               x="357.14099"
+               y="241.245"
+               class="st0 st1 st2"
+               font-size="209.87"
+               font-weight="bold"
+               style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#24af63"><tspan
+                 id="tspan73"
+                 style="fill:#050505">core/</tspan></tspan></text>
+          <text
+             id="text59"
+             x="-260.04999"
              y="457.04501"
-             class="st1 st2"
-             font-size="209.87"
              font-weight="bold"
-             style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#050505">pairgenomealign</tspan></text><path
-           id="path67"
-           d="m 300.437,166.116 -21.532,21.616 h 61.092 v -21.617 z"
-           style="fill:url(#f)" /><text
-           id="text4"
-           x="1334.3921"
-           y="241.245"
-           font-size="209.87"
-           font-weight="bold"
-           style="font-weight:700;font-size:209.87px;font-family:'Maven Pro';fill:#050505;fill-opacity:1"><tspan
-             id="tspan4"
+             style="font-weight:700;font-family:'Maven Pro'"><tspan
+               id="tspan61"
+               x="47.849998"
+               y="457.04501"
+               class="st1 st2"
+               font-size="209.87"
+               font-weight="bold"
+               style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#050505">pairgenomealign</tspan></text>
+          <path
+             id="path67"
+             d="m 300.437,166.116 -21.532,21.616 h 61.092 v -21.617 z"
+             style="fill:url(#f)" />
+          <text
+             id="text4"
              x="1334.3921"
              y="241.245"
-             class="st0 st1 st2"
              font-size="209.87"
              font-weight="bold"
-             style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#050505;fill-opacity:1">v3.0</tspan></text></g></g><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="326.45081"
-       y="98.816368"
-       id="text3"><tspan
-         sodipodi:role="line"
-         id="tspan3"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="326.45081"
-         y="98.816368">Align</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="30.898579"
-       y="51.279114"
-       id="text3-3"><tspan
-         sodipodi:role="line"
-         id="tspan3-5"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="30.898579"
-         y="51.279114">Input</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="328.35934"
-       y="120.50598"
-       id="text3-5"><tspan
-         sodipodi:role="line"
-         id="tspan3-3"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="328.35934"
-         y="120.50598">Refine</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="324.23535"
-       y="155.71509"
-       id="text3-9"><tspan
-         sodipodi:role="line"
-         id="tspan3-1"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="324.23535"
-         y="155.71509">Plot</tspan></text><text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="328.72269"
-       y="180.3985"
-       id="text3-93"><tspan
-         sodipodi:role="line"
-         id="tspan3-6"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="328.72269"
-         y="180.3985">Export</tspan></text><ellipse
-       style="fill:#ffffff;stroke:#000000;stroke-width:2.64583;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
-       id="ellipse1"
-       cx="127.22503"
-       cy="131.32678"
-       rx="5.9872503"
-       ry="6.2987328"
-       transform="matrix(1,0,0.00362725,0.99999342,0,0)" /><text
-       xml:space="preserve"
-       transform="matrix(0.26458333,0,0,0.26458333,80.959933,-59.127044)"
-       id="text22"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect22);display:inline;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
-       x="0"
-       y="0"><tspan
-         x="69.048828"
-         y="710.89126"
-         id="tspan18"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan17">htslib
+             style="font-weight:700;font-size:209.87px;font-family:'Maven Pro';fill:#050505;fill-opacity:1"><tspan
+               id="tspan4"
+               x="1334.3921"
+               y="241.245"
+               class="st0 st1 st2"
+               font-size="209.87"
+               font-weight="bold"
+               style="font-weight:700;font-size:209.867px;font-family:'Maven Pro';fill:#050505;fill-opacity:1">v3.0</tspan></text>
+        </g>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="100.3083"
+         y="35.170837"
+         id="text3"><tspan
+           sodipodi:role="line"
+           id="tspan3"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="100.3083"
+           y="35.170837">Index</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="12.033007"
+         y="34.731102"
+         id="text3-3"><tspan
+           sodipodi:role="line"
+           id="tspan3-5"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="12.033007"
+           y="34.731102">Input</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="190.29919"
+         y="35.244129"
+         id="text3-5"><tspan
+           sodipodi:role="line"
+           id="tspan3-3"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="190.29919"
+           y="35.244129">Refine</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="229.0416"
+         y="35.024254"
+         id="text3-9"><tspan
+           sodipodi:role="line"
+           id="tspan3-1"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="229.0416"
+           y="35.024254">Plot</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="254.85303"
+         y="34.804394"
+         id="text3-93"><tspan
+           sodipodi:role="line"
+           id="tspan3-6"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="254.85303"
+           y="34.804394">Export</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="62.127258"
+         y="34.877686"
+         id="text3-1"><tspan
+           sodipodi:role="line"
+           id="tspan3-2"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="62.127258"
+           y="34.877686">QC</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="126.09169"
+         y="34.950958"
+         id="text23"><tspan
+           sodipodi:role="line"
+           id="tspan23"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="126.09169"
+           y="34.950958">Train</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="151.80193"
+         y="34.65781"
+         id="text24"><tspan
+           sodipodi:role="line"
+           id="tspan24"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="151.80193"
+           y="34.65781">Align</tspan></text>
+      <path
+         id="ellipse27"
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.68495;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 49.317601,50.149061 a 3.0174769,2.0780019 89.713614 0 0 -2.070273,3.017312 3.0174769,2.0780019 89.713614 0 0 0.524359,1.985466 3.0174769,2.0780019 89.713614 0 0 -0.524358,2.002577 3.0174769,2.0780019 89.713614 0 0 2.086214,3.017324 3.0174769,2.0780019 89.713614 0 0 2.069683,-3.017324 3.0174769,2.0780019 89.713614 0 0 -0.52377,-1.985454 3.0174769,2.0780019 89.713614 0 0 0.52377,-2.002589 3.0174769,2.0780019 89.713614 0 0 -2.085625,-3.017312 z" />
+      <g
+         id="g171"
+         transform="matrix(1.2135653,0,0,1.2135653,0.26322898,-8.9009647)">
+        <g
+           id="g133"
+           transform="translate(-23.851935,-42.917214)">
+          <rect
+             style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+             id="rect43"
+             width="1.2143828"
+             height="6.2979465"
+             x="-85.160133"
+             y="169.28697"
+             ry="0.60719138"
+             rx="0.60719138"
+             transform="matrix(0,1,1,0,39.983515,182.8712)" />
+          <g
+             id="g45"
+             transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+             style="stroke-width:2.97415;stroke-dasharray:none">
+            <path
+               style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+               id="path43"
+               sodipodi:nodetypes="ccc" />
+          </g>
+          <g
+             id="g113-2"
+             transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <g
+               id="g112-9"
+               transform="translate(-68.54295,-4.5648763)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <text
+                 xml:space="preserve"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                 x="328.28516"
+                 y="91.270317"
+                 id="text112-1"><tspan
+                   sodipodi:role="line"
+                   id="tspan112-2"
+                   style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                   x="328.28516"
+                   y="91.270317">PNG</tspan></text>
+            </g>
+          </g>
+        </g>
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.00001;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse42"
+           cx="188.38448"
+           cy="50.465446"
+           rx="1.818553"
+           ry="1.9131618"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      </g>
+      <ellipse
+         style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         id="ellipse63"
+         cx="280.53522"
+         cy="52.342098"
+         rx="2.2069328"
+         ry="2.3217468"
+         transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:19.5433;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="200.36678"
+         y="108.52708"
+         id="text67"
+         transform="matrix(1.2135653,0,0,1.2135653,37.382426,-88.847345)"><tspan
+           x="200.36678"
+           y="108.52708"
+           id="tspan74"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan72">samtools/</tspan>
+</tspan><tspan
+           x="200.36678"
+           y="112.35071"
+           id="tspan76"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan75">merge</tspan></tspan></text>
+      <g
+         id="g68"
+         transform="matrix(0.54412524,0,0,0.71563875,144.64621,-5.5025813)"
+         style="stroke:#243264;stroke-width:2.97415;stroke-dasharray:none;stroke-opacity:0.992157">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#243264;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+           d="M 83.506392,101.51599 H 150.14128"
+           id="path68"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <ellipse
+         style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         id="ellipse71"
+         cx="255.10352"
+         cy="-52.342098"
+         rx="2.2069328"
+         ry="2.3217468"
+         transform="matrix(1,0,0.00362725,-0.99999342,0,0)" />
+      <g
+         id="g80"
+         transform="matrix(0.58042331,0,0,0.71563875,142.40726,42.368202)"
+         style="stroke:#f696f4;stroke-width:2.97415;stroke-dasharray:none;stroke-opacity:0.560784">
+        <path
+           style="fill:none;fill-opacity:1;stroke:#f696f4;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.560784"
+           d="M 56.356386,55.310626 H 150.14128"
+           id="path80"
+           sodipodi:nodetypes="cc" />
+      </g>
+      <ellipse
+         style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         id="ellipse74"
+         cx="177.18213"
+         cy="81.95118"
+         rx="2.2069328"
+         ry="2.3217468"
+         transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      <ellipse
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         id="ellipse40"
+         cx="100.24227"
+         cy="52.342098"
+         rx="2.2069328"
+         ry="2.3217468"
+         transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      <path
+         style="fill:none;fill-opacity:1;stroke:#24b064;stroke-width:2.09453;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.992157"
+         d="m 152.58764,96.755071 h 77.2862"
+         id="path84"
+         sodipodi:nodetypes="cc" />
+      <g
+         id="g175"
+         transform="matrix(1.2135653,0,0,1.2135653,-110.07066,-22.2448)">
+        <g
+           id="g99"
+           transform="matrix(0.59030223,0,0,0.59030223,102.12623,57.630093)">
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+             x="186.70786"
+             y="119.51638"
+             id="text95"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
+               x="186.70786"
+               y="125.68999"
+               id="tspan95" /></text>
+          <g
+             id="g98"
+             transform="translate(90.32707,-56.097864)"
+             style="fill:#23b064;fill-opacity:0.992157;stroke:none">
+            <ellipse
+               style="fill:#23b064;fill-opacity:0.992157;stroke:none;stroke-width:1.68983;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+               id="ellipse95"
+               cx="189.20058"
+               cy="124.59148"
+               rx="6.4652696"
+               ry="2.3793285"
+               transform="matrix(1,0,0.01036896,0.99994624,0,0)" />
+            <g
+               id="g97"
+               transform="translate(-69.002889,39.380393)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <g
+                 id="g96"
+                 transform="translate(-68.54295,-4.5648763)"
+                 style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+                <text
+                   xml:space="preserve"
+                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                   x="328.0383"
+                   y="91.176842"
+                   id="text96"><tspan
+                     sodipodi:role="line"
+                     id="tspan96"
+                     style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                     x="328.0383"
+                     y="91.176842">m2m</tspan></text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g174"
+         transform="matrix(1.2135653,0,0,1.2135653,-110.07066,-15.02595)">
+        <g
+           id="g104"
+           transform="matrix(0.59030223,0,0,0.59030223,102.12623,39.482492)">
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+             x="186.70786"
+             y="119.51638"
+             id="text100"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
+               x="186.70786"
+               y="125.68999"
+               id="tspan100" /></text>
+          <g
+             id="g103"
+             transform="translate(90.32707,-56.097864)"
+             style="fill:#23b064;fill-opacity:0.992157;stroke:none">
+            <ellipse
+               style="fill:#f696f4;fill-opacity:0.560784;stroke:none;stroke-width:1.68983;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+               id="ellipse100"
+               cx="189.20058"
+               cy="124.59148"
+               rx="6.4652696"
+               ry="2.3793285"
+               transform="matrix(1,0,0.01036896,0.99994624,0,0)" />
+            <g
+               id="g102"
+               transform="translate(-69.002889,39.380393)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <g
+                 id="g101"
+                 transform="translate(-68.54295,-4.5648763)"
+                 style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+                <text
+                   xml:space="preserve"
+                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                   x="328.0383"
+                   y="91.176842"
+                   id="text101"><tspan
+                     sodipodi:role="line"
+                     id="tspan101"
+                     style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                     x="328.0383"
+                     y="91.176842">o2m</tspan></text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g172"
+         transform="matrix(1.2135653,0,0,1.2135653,-110.07066,-9.670001)">
+        <g
+           id="g111"
+           transform="matrix(0.59030223,0,0,0.59030223,102.12623,10.670837)">
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+             x="186.70786"
+             y="119.51638"
+             id="text104"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
+               x="186.70786"
+               y="125.68999"
+               id="tspan104" /></text>
+          <g
+             id="g107"
+             transform="translate(90.32707,-56.097864)"
+             style="fill:#23b064;fill-opacity:0.992157;stroke:none">
+            <ellipse
+               style="fill:#8d1964;fill-opacity:1;stroke:none;stroke-width:1.68983;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+               id="ellipse104"
+               cx="189.20058"
+               cy="124.59148"
+               rx="6.4652696"
+               ry="2.3793285"
+               transform="matrix(1,0,0.01036896,0.99994624,0,0)" />
+            <g
+               id="g106"
+               transform="translate(-69.002889,39.380393)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <g
+                 id="g105"
+                 transform="translate(-68.54295,-4.5648763)"
+                 style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+                <text
+                   xml:space="preserve"
+                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                   x="328.0383"
+                   y="91.176842"
+                   id="text105"><tspan
+                     sodipodi:role="line"
+                     id="tspan105"
+                     style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                     x="328.0383"
+                     y="91.176842">o2o</tspan></text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g173"
+         transform="matrix(1.2135653,0,0,1.2135653,-110.07066,-12.802068)">
+        <g
+           id="g118"
+           transform="matrix(0.59030223,0,0,0.59030223,102.12623,25.450842)">
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+             x="186.70786"
+             y="119.51638"
+             id="text111"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
+               x="186.70786"
+               y="125.68999"
+               id="tspan111" /></text>
+          <g
+             id="g114"
+             transform="translate(90.32707,-56.097864)"
+             style="fill:#23b064;fill-opacity:0.992157;stroke:none">
+            <ellipse
+               style="fill:#233164;fill-opacity:0.992157;stroke:none;stroke-width:1.68983;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+               id="ellipse111"
+               cx="189.20058"
+               cy="124.59148"
+               rx="6.4652696"
+               ry="2.3793285"
+               transform="matrix(1,0,0.01036896,0.99994624,0,0)" />
+            <g
+               id="g113"
+               transform="translate(-69.002889,39.380393)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <g
+                 id="g112"
+                 transform="translate(-68.54295,-4.5648763)"
+                 style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+                <text
+                   xml:space="preserve"
+                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                   x="328.0383"
+                   y="91.176842"
+                   id="text112"><tspan
+                     sodipodi:role="line"
+                     id="tspan112"
+                     style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                     x="328.0383"
+                     y="91.176842">m2o</tspan></text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:51.2927;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="76.481003"
+         y="77.884949"
+         id="text122"
+         transform="matrix(1.2135644,-0.00150835,0.00150835,1.2135644,-43.719796,-51.189995)"><tspan
+           x="76.481003"
+           y="77.884949"
+           id="tspan78"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan77">assembly-
 </tspan></tspan><tspan
-         x="93.130859"
-         y="724.22457"
-         id="tspan20"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan19">/
+           x="76.481003"
+           y="81.708581"
+           id="tspan80"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan79">scan</tspan></tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:13.0064;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="169.12553"
+         y="108.55206"
+         id="text126"
+         transform="matrix(1.2135653,0,0,1.2135653,-27.904242,-88.865574)"><tspan
+           x="169.12553"
+           y="108.55206"
+           id="tspan82"><tspan
+   style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+   id="tspan81">last/</tspan>
+</tspan><tspan
+           x="169.12553"
+           y="112.3757"
+           id="tspan84"><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan83">split</tspan></tspan></text>
+      <path
+         id="path129"
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.42713;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 49.317601,50.149061 a 3.0174769,2.0780019 89.713614 0 0 -2.070273,3.017312 3.0174769,2.0780019 89.713614 0 0 0.524359,1.985466 3.0174769,2.0780019 89.713614 0 0 -0.524358,2.002577 3.0174769,2.0780019 89.713614 0 0 2.086214,3.017324 3.0174769,2.0780019 89.713614 0 0 2.069683,-3.017324 3.0174769,2.0780019 89.713614 0 0 -0.52377,-1.985454 3.0174769,2.0780019 89.713614 0 0 0.52377,-2.002589 3.0174769,2.0780019 89.713614 0 0 -2.085625,-3.017312 z" />
+      <path
+         id="path131"
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.42713;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 74.87103,50.149061 a 3.0174769,2.0780019 89.713614 0 0 -2.070274,3.017312 3.0174769,2.0780019 89.713614 0 0 0.52436,1.985466 3.0174769,2.0780019 89.713614 0 0 -0.524358,2.002577 3.0174769,2.0780019 89.713614 0 0 2.086214,3.017324 3.0174769,2.0780019 89.713614 0 0 2.069682,-3.017324 3.0174769,2.0780019 89.713614 0 0 -0.523769,-1.985454 3.0174769,2.0780019 89.713614 0 0 0.523769,-2.002589 3.0174769,2.0780019 89.713614 0 0 -2.085624,-3.017312 z" />
+      <path
+         id="path133"
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.42713;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 125.97787,50.149061 c -1.14769,-1.46e-4 -2.07459,1.350769 -2.07027,3.017312 0.004,0.731304 -2.8e-4,3.248852 0,3.988043 0.005,1.666598 0.93849,3.017541 2.08622,3.017324 1.14746,-3.3e-4 2.074,-1.351113 2.06967,-3.017324 -0.004,-0.731189 4.5e-4,-3.248961 0,-3.988043 -0.005,-1.666255 -0.93813,-3.017052 -2.08562,-3.017312 z"
+         sodipodi:nodetypes="ccccccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.05439px;line-height:1.38971px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.379079;stroke-dashoffset:624.756"
+         x="280.7251"
+         y="35.097546"
+         id="text133"><tspan
+           sodipodi:role="line"
+           id="tspan133"
+           style="font-size:5.05439px;line-height:1.38971px;stroke-width:0.379079"
+           x="280.7251"
+           y="35.097546">Combine</tspan></text>
+      <g
+         id="g151"
+         transform="matrix(1.2135653,0,0,1.2135653,-54.494077,-60.983808)">
+        <rect
+           style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+           id="rect147"
+           width="1.2143828"
+           height="6.2979465"
+           x="-85.160133"
+           y="169.28697"
+           ry="0.60719138"
+           rx="0.60719138"
+           transform="matrix(0,1,1,0,39.983515,182.8712)" />
+        <g
+           id="g148"
+           transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+           style="stroke-width:2.97415;stroke-dasharray:none">
+          <path
+             style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+             id="path147"
+             sodipodi:nodetypes="ccc" />
+        </g>
+        <g
+           id="g150"
+           transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+           style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+          <g
+             id="g149"
+             transform="translate(-68.54295,-4.5648763)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <text
+               xml:space="preserve"
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+               x="328.28516"
+               y="91.270317"
+               id="text148"><tspan
+                 sodipodi:role="line"
+                 id="tspan148"
+                 style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                 x="328.28516"
+                 y="91.270317">MAF</tspan></text>
+          </g>
+        </g>
+      </g>
+      <g
+         id="g170"
+         transform="matrix(1.2135653,0,0,1.2135653,0.26322898,-10.443722)">
+        <g
+           id="g159"
+           transform="translate(-23.851935,-29.44683)">
+          <rect
+             style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+             id="rect155"
+             width="1.2143828"
+             height="6.2979465"
+             x="-85.160133"
+             y="169.28697"
+             ry="0.60719138"
+             rx="0.60719138"
+             transform="matrix(0,1,1,0,39.983515,182.8712)" />
+          <g
+             id="g156"
+             transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+             style="stroke-width:2.97415;stroke-dasharray:none">
+            <path
+               style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+               id="path155"
+               sodipodi:nodetypes="ccc" />
+          </g>
+          <g
+             id="g158"
+             transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <g
+               id="g157"
+               transform="translate(-68.54295,-4.5648763)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <text
+                 xml:space="preserve"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                 x="328.28516"
+                 y="91.270317"
+                 id="text156"><tspan
+                   sodipodi:role="line"
+                   id="tspan156"
+                   style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                   x="328.28516"
+                   y="91.270317">PNG</tspan></text>
+            </g>
+          </g>
+        </g>
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.00001;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse159"
+           cx="188.33562"
+           cy="63.935921"
+           rx="1.818553"
+           ry="1.9131618"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      </g>
+      <g
+         id="g169"
+         transform="matrix(1.2135653,0,0,1.2135653,0.26322898,-10.851237)">
+        <g
+           id="g163"
+           transform="translate(-23.851935,-16.911889)">
+          <rect
+             style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+             id="rect160"
+             width="1.2143828"
+             height="6.2979465"
+             x="-85.160133"
+             y="169.28697"
+             ry="0.60719138"
+             rx="0.60719138"
+             transform="matrix(0,1,1,0,39.983515,182.8712)" />
+          <g
+             id="g160"
+             transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+             style="stroke-width:2.97415;stroke-dasharray:none">
+            <path
+               style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+               id="path160"
+               sodipodi:nodetypes="ccc" />
+          </g>
+          <g
+             id="g162"
+             transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <g
+               id="g161"
+               transform="translate(-68.54295,-4.5648763)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <text
+                 xml:space="preserve"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                 x="328.28516"
+                 y="91.270317"
+                 id="text160"><tspan
+                   sodipodi:role="line"
+                   id="tspan160"
+                   style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                   x="328.28516"
+                   y="91.270317">PNG</tspan></text>
+            </g>
+          </g>
+        </g>
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.00001;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse163"
+           cx="188.29015"
+           cy="76.47094"
+           rx="1.818553"
+           ry="1.9131618"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      </g>
+      <g
+         id="g168"
+         transform="matrix(1.2135653,0,0,1.2135653,0.26322898,-20.340542)">
+        <g
+           id="g167"
+           transform="translate(-23.851935,3.106599)">
+          <rect
+             style="fill:#000000;stroke:#000000;stroke-width:0.874534;stroke-linecap:round;paint-order:stroke markers fill;stop-color:#000000"
+             id="rect163"
+             width="1.2143828"
+             height="6.2979465"
+             x="-85.160133"
+             y="169.28697"
+             ry="0.60719138"
+             rx="0.60719138"
+             transform="matrix(0,1,1,0,39.983515,182.8712)" />
+          <g
+             id="g164"
+             transform="matrix(0,-0.02833659,-0.59141125,0,245.1306,99.490368)"
+             style="stroke-width:2.97415;stroke-dasharray:none">
+            <path
+               style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.97415;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 46.404836,55.310006 54.019664,6.2e-4 h 49.71678"
+               id="path163"
+               sodipodi:nodetypes="ccc" />
+          </g>
+          <g
+             id="g166"
+             transform="matrix(0.59030222,0,0,0.59030222,59.093062,47.970491)"
+             style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+            <g
+               id="g165"
+               transform="translate(-68.54295,-4.5648763)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <text
+                 xml:space="preserve"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                 x="328.28516"
+                 y="91.270317"
+                 id="text164"><tspan
+                   sodipodi:role="line"
+                   id="tspan164"
+                   style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                   x="328.28516"
+                   y="91.270317">PNG</tspan></text>
+            </g>
+          </g>
+        </g>
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.00001;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse167"
+           cx="188.21753"
+           cy="96.489563"
+           rx="1.818553"
+           ry="1.9131618"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+      </g>
+      <path
+         id="path5"
+         style="fill:#ffffff;stroke:#000000;stroke-width:2.42713;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 151.6603,50.149061 c -1.1477,-1.46e-4 -2.07459,1.350769 -2.07027,3.017312 0.004,0.731304 -2.8e-4,3.248852 0,3.988043 0.005,1.666598 0.93848,3.017541 2.08621,3.017324 1.14747,-3.3e-4 2.07401,-1.351113 2.06968,-3.017324 -0.004,-0.731189 4.5e-4,-3.248961 0,-3.988043 -0.005,-1.666255 -0.93814,-3.017052 -2.08562,-3.017312 z"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         id="path7"
+         style="fill:#ffffff;stroke:#666666;stroke-width:2.42713;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+         d="m 151.6603,91.743732 c -1.1477,-1.47e-4 -2.07459,1.350768 -2.07027,3.017311 0.004,0.731305 -2.8e-4,3.248852 0,3.988043 0.005,1.666594 0.93848,3.017544 2.08621,3.017324 1.14747,-3.3e-4 2.07401,-1.35111 2.06968,-3.017324 -0.004,-0.731189 4.5e-4,-3.248961 0,-3.988043 -0.005,-1.666255 -0.93814,-3.017052 -2.08562,-3.017311 z"
+         sodipodi:nodetypes="ccccccc" />
+      <g
+         id="g17"
+         transform="matrix(1.2135653,0,0,1.2135653,-159.76,-27.589266)">
+        <g
+           id="g16"
+           transform="matrix(0.59030223,0,0,0.59030223,102.12623,25.450842)">
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.32292;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+             x="186.70786"
+             y="119.51638"
+             id="text12"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.32292"
+               x="186.70786"
+               y="125.68999"
+               id="tspan12" /></text>
+          <g
+             id="g15"
+             transform="translate(90.32707,-56.097864)"
+             style="fill:#23b064;fill-opacity:0.992157;stroke:none">
+            <ellipse
+               style="fill:#233164;fill-opacity:0.992157;stroke:none;stroke-width:1.68983;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+               id="ellipse12"
+               cx="189.20058"
+               cy="124.59148"
+               rx="6.4652696"
+               ry="2.3793285"
+               transform="matrix(1,0,0.01036896,0.99994624,0,0)" />
+            <g
+               id="g14"
+               transform="translate(-69.002889,39.380393)"
+               style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+              <g
+                 id="g13"
+                 transform="translate(-68.54295,-4.5648763)"
+                 style="fill:#ffffff;fill-opacity:0.992157;stroke:none">
+                <text
+                   xml:space="preserve"
+                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:4.23333px;line-height:1.16396px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
+                   x="328.0383"
+                   y="91.176842"
+                   id="text13"><tspan
+                     sodipodi:role="line"
+                     id="tspan13"
+                     style="font-size:4.23333px;line-height:1.16396px;fill:#ffffff;fill-opacity:0.992157;stroke:none;stroke-width:0.529167"
+                     x="328.0383"
+                     y="91.176842">m2o</tspan></text>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <path
+         style="fill:#999999;fill-opacity:1;stroke:#4d4d4d;stroke-width:0.606783;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:0.204165, 0.340274;stroke-dashoffset:29.2637;stroke-opacity:0.992157;marker-end:url(#Triangle)"
+         d="M 3.0756786,38.361132 H 292.29589"
+         id="path17"
+         sodipodi:nodetypes="cc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.91544px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro';text-align:center;text-anchor:middle;white-space:pre;inline-size:51.6724;display:inline;opacity:0.99;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.780923;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.717647"
+         x="117.15866"
+         y="77.539764"
+         id="text36"
+         transform="matrix(0.33799079,1.1655484,-1.1655484,0.33799079,189.76844,-83.52498)"><tspan
+           x="117.15866"
+           y="77.539764"
+           id="tspan87"><tspan
+             style="font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+             id="tspan85">Optional route: </tspan><tspan
+             style="font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono'"
+             id="tspan86">--m2m</tspan></tspan></text>
+      <rect
+         x="45.622864"
+         y="62.89452"
+         width="79.219231"
+         height="46.665501"
+         rx="2.8876898"
+         fill="#ffffff"
+         stroke="#111111"
+         stroke-width="0.529411"
+         id="rect102" />
+      <text
+         x="50.43568"
+         y="70.11377"
+         font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+         font-size="4.0909px"
+         font-weight="bold"
+         text-anchor="start"
+         fill="#111111"
+         id="text103"
+         style="stroke-width:0.240642">Two ways to reach o2o</text>
+      <rect
+         x="51.879532"
+         y="75.407845"
+         width="35.807354"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#1b1b1b"
+         id="rect103"
+         style="stroke-width:0.240642" />
+      <text
+         x="69.78318"
+         y="79.498726"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text104-0"
+         style="stroke-width:0.240642">lastal --split</text>
+      <line
+         x1="89.130714"
+         y1="78.29554"
+         x2="93.462257"
+         y2="78.29554"
+         stroke="#243264"
+         stroke-width="1.44385"
+         stroke-linecap="round"
+         id="line104" />
+      <rect
+         x="93.462257"
+         y="75.407845"
+         width="10.13098"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#243264"
+         id="rect104"
+         style="stroke-width:0.240642" />
+      <text
+         x="98.515709"
+         y="79.498726"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text105-4"
+         style="stroke-width:0.240642">m2o</text>
+      <line
+         x1="105.03706"
+         y1="78.29554"
+         x2="109.36861"
+         y2="78.29554"
+         stroke="#8d1964"
+         stroke-width="1.44385"
+         stroke-linecap="round"
+         id="line105" />
+      <rect
+         x="109.36861"
+         y="75.407845"
+         width="10.13098"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#8d1964"
+         id="rect105"
+         style="stroke-width:0.240642" />
+      <text
+         x="114.42207"
+         y="79.498726"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text106"
+         style="stroke-width:0.240642">o2o</text>
+      <text
+         x="51.879532"
+         y="85.51474"
+         font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+         font-size="2.76737px"
+         font-weight="normal"
+         text-anchor="start"
+         fill="#5f5f5f"
+         id="text107"
+         style="stroke-width:0.240642">Default: two stops, no full m2m written to disk.</text>
+      <rect
+         x="51.879532"
+         y="91.771416"
+         width="17.133627"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#5f5f5f"
+         id="rect107"
+         style="stroke-width:0.240642" />
+      <text
+         x="60.446339"
+         y="95.862335"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text108"
+         style="stroke-width:0.240642">lastal</text>
+      <line
+         x1="70.457001"
+         y1="94.659126"
+         x2="74.788528"
+         y2="94.659126"
+         stroke="#24b064"
+         stroke-width="1.44385"
+         stroke-linecap="round"
+         stroke-dasharray="2.5, 3.5"
+         id="line108" />
+      <rect
+         x="74.788528"
+         y="91.771416"
+         width="10.13098"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#24b064"
+         id="rect108"
+         style="stroke-width:0.240642" />
+      <text
+         x="79.841995"
+         y="95.862335"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text109"
+         style="stroke-width:0.240642">m2m</text>
+      <line
+         x1="86.363342"
+         y1="94.659126"
+         x2="90.694885"
+         y2="94.659126"
+         stroke="#243264"
+         stroke-width="1.44385"
+         stroke-linecap="round"
+         stroke-dasharray="2.5, 3.5"
+         id="line109" />
+      <rect
+         x="90.694885"
+         y="91.771416"
+         width="10.13098"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#243264"
+         id="rect109"
+         style="stroke-width:0.240642" />
+      <text
+         x="95.748329"
+         y="95.862335"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text110"
+         style="stroke-width:0.240642">m2o</text>
+      <line
+         x1="102.26972"
+         y1="94.659126"
+         x2="106.60126"
+         y2="94.659126"
+         stroke="#8d1964"
+         stroke-width="1.44385"
+         stroke-linecap="round"
+         stroke-dasharray="2.5, 3.5"
+         id="line110" />
+      <rect
+         x="106.60126"
+         y="91.771416"
+         width="10.13098"
+         height="5.7753797"
+         rx="2.8876898"
+         fill="#8d1964"
+         id="rect110"
+         style="stroke-width:0.240642" />
+      <text
+         x="111.65472"
+         y="95.862335"
+         font-family="'DejaVu Sans Mono', Consolas, monospace"
+         font-size="3.008px"
+         font-weight="bold"
+         text-anchor="middle"
+         fill="#ffffff"
+         id="text111-6"
+         style="stroke-width:0.240642">o2o</text>
+      <text
+         x="51.879532"
+         y="101.87836"
+         font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+         font-size="2.76737px"
+         font-weight="normal"
+         text-anchor="start"
+         fill="#5f5f5f"
+         id="text112-2"
+         style="stroke-width:0.240642">With --m2m: three stops, and m2m is kept.</text>
+      <g
+         id="g39"
+         transform="translate(-2.5982558)">
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse39-3"
+           cx="171.9229"
+           cy="113.90827"
+           rx="2.2069328"
+           ry="2.3217468"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse39-2"
+           cx="191.09724"
+           cy="113.90827"
+           rx="2.2069328"
+           ry="2.3217468"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+        <ellipse
+           style="fill:#ffffff;stroke:#666666;stroke-width:2.42714;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;paint-order:stroke markers fill;stop-color:#000000"
+           id="ellipse39-7"
+           cx="210.27162"
+           cy="113.90827"
+           rx="2.2069328"
+           ry="2.3217468"
+           transform="matrix(1,0,0.00362725,0.99999342,0,0)" />
+        <text
+           xml:space="preserve"
+           transform="matrix(0.18953965,0,0,0.18953965,149.98779,-28.22842)"
+           id="text28"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect28);display:inline;fill:#666666;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
+           x="0"
+           y="0"><tspan
+             x="160.33008"
+             y="710.89126"
+             id="tspan89"><tspan
+               style="text-align:center;text-anchor:middle;stroke:#ffffff"
+               id="tspan88">subworkflow: </tspan></tspan><tspan
+             x="68.818359"
+             y="724.22457"
+             id="tspan91"><tspan
+               style="text-align:center;text-anchor:middle;stroke:#ffffff"
+               id="tspan90">fasta_bgzip_index_dict_samtools
+</tspan></tspan></text>
+        <text
+           xml:space="preserve"
+           transform="matrix(0.18953965,0,0,0.18953965,172.78785,-13.739997)"
+           id="text7814-8"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect7816-0);display:inline;fill:#666666;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
+           x="0"
+           y="0"><tspan
+             x="59.416016"
+             y="710.89126"
+             id="tspan93"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan92">samtools
 </tspan></tspan><tspan
-         x="49.783203"
-         y="737.55789"
-         id="tspan22"><tspan
-           style="text-align:center;text-anchor:middle;fill:#000000"
-           id="tspan21">bgziptabix</tspan></tspan></text><text
+             x="93.130859"
+             y="724.22457"
+             id="tspan97"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan94">/
+</tspan></tspan><tspan
+             x="73.865234"
+             y="737.55789"
+             id="tspan99"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan98">faidx</tspan></tspan></text>
+        <text
+           xml:space="preserve"
+           transform="matrix(0.18953965,0,0,0.18953965,191.96222,-13.739997)"
+           id="text7814-5-2"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect7816-5-7);display:inline;fill:#666666;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
+           x="0"
+           y="0"><tspan
+             x="59.416016"
+             y="710.89126"
+             id="tspan103"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan102">samtools
+</tspan></tspan><tspan
+             x="93.130859"
+             y="724.22457"
+             id="tspan107"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan106">/
+</tspan></tspan><tspan
+             x="78.681641"
+             y="737.55789"
+             id="tspan109"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan108">dict</tspan></tspan></text>
+        <text
+           xml:space="preserve"
+           transform="matrix(0.18953965,0,0,0.18953965,153.68457,-14.044297)"
+           id="text22-6"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:13.3333px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:justify;white-space:pre;shape-inside:url(#rect22-5);display:inline;fill:#666666;fill-opacity:1;stroke:#000000;stroke-width:0.4;stroke-dashoffset:624.756;stroke-opacity:0"
+           x="0"
+           y="0"><tspan
+             x="69.048828"
+             y="710.89126"
+             id="tspan113"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan110">htslib
+</tspan></tspan><tspan
+             x="93.130859"
+             y="724.22457"
+             id="tspan115"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan114">/
+</tspan></tspan><tspan
+             x="49.783203"
+             y="737.55789"
+             id="tspan117"><tspan
+               style="text-align:center;text-anchor:middle"
+               id="tspan116">bgziptabix</tspan></tspan></text>
+      </g>
+      <g
+         id="g37"
+         transform="matrix(0.47583709,0,0,0.47583709,-33.870457,128.51729)">
+        <rect
+           x="82.631081"
+           y="-24.295681"
+           width="234.57283"
+           height="41.274998"
+           rx="3.175"
+           fill="#ffffff"
+           stroke="#111111"
+           stroke-width="0.582083"
+           id="rect117" />
+        <text
+           x="87.922752"
+           y="-16.887348"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="4.49792px"
+           font-weight="bold"
+           text-anchor="start"
+           fill="#111111"
+           id="text118"
+           style="stroke-width:0.264583">Key</text>
+        <ellipse
+           cx="90.039421"
+           cy="-10.008181"
+           rx="1.7197917"
+           ry="4.4979167"
+           fill="#ffffff"
+           stroke="#111111"
+           stroke-width="1.5875"
+           id="ellipse118" />
+        <text
+           x="94.801918"
+           y="-8.6852646"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text119"
+           style="stroke-width:0.264583">input</text>
+        <circle
+           cx="119.67275"
+           cy="-10.008181"
+           r="3.7041667"
+           fill="#ffffff"
+           stroke="#111111"
+           stroke-width="1.85208"
+           id="circle119" />
+        <text
+           x="125.49358"
+           y="-8.6852646"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text120"
+           style="stroke-width:0.264583">module</text>
+        <circle
+           cx="153.53941"
+           cy="-10.008181"
+           r="3.7041667"
+           fill="#ffffff"
+           stroke="#5f5f5f"
+           stroke-width="1.32292"
+           id="circle120" />
+        <text
+           x="159.36024"
+           y="-8.6852646"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text121"
+           style="stroke-width:0.264583">module, optional</text>
+        <path
+           d="m 198.78317,-12.389431 a 3.4395835,3.4395835 0 0 1 6.87916,0 v 4.7625001 a 3.4395835,3.4395835 0 0 1 -6.87916,0 z"
+           fill="#ffffff"
+           stroke="#111111"
+           stroke-width="1.85208"
+           id="path121" />
+        <text
+           x="208.04358"
+           y="-8.6852646"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text122-9"
+           style="stroke-width:0.264583">one module, several lines</text>
+        <ellipse
+           cx="267.83942"
+           cy="-10.008181"
+           rx="3.96875"
+           ry="1.984375"
+           fill="#111111"
+           id="ellipse122"
+           style="stroke-width:0.264583" />
+        <text
+           x="273.66025"
+           y="-8.6852646"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text123"
+           style="stroke-width:0.264583">output file</text>
+        <line
+           x1="88.981094"
+           y1="-1.0123465"
+           x2="103.26859"
+           y2="-1.0123465"
+           stroke="#000000"
+           stroke-width="3.43958"
+           stroke-linecap="round"
+           id="line123" />
+        <text
+           x="106.44358"
+           y="0.31056765"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text124"
+           style="stroke-width:0.264583">target genome</text>
+        <line
+           x1="88.981094"
+           y1="4.808485"
+           x2="103.26859"
+           y2="4.808485"
+           stroke="#7eb2dd"
+           stroke-width="2.91042"
+           stroke-linecap="round"
+           id="line124" />
+        <text
+           x="106.44358"
+           y="6.131403"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text125"
+           style="stroke-width:0.264583">query genome(s)</text>
+        <line
+           x1="88.981094"
+           y1="10.629316"
+           x2="103.26859"
+           y2="10.629316"
+           stroke="#808000"
+           stroke-width="1.32292"
+           stroke-linecap="round"
+           id="line125" />
+        <text
+           x="106.44358"
+           y="11.952234"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text126-0"
+           style="stroke-width:0.264583">alignment parameters (last-train)</text>
+        <line
+           x1="174.17691"
+           y1="-1.0123465"
+           x2="188.46442"
+           y2="-1.0123465"
+           stroke="#243264"
+           stroke-width="3.43958"
+           stroke-linecap="round"
+           id="line126" />
+        <text
+           x="191.63942"
+           y="0.31056765"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text127"
+           style="stroke-width:0.264583">many-to-one m2o</text>
+        <line
+           x1="174.17691"
+           y1="4.808485"
+           x2="188.46442"
+           y2="4.808485"
+           stroke="#8d1964"
+           stroke-width="3.43958"
+           stroke-linecap="round"
+           id="line127" />
+        <text
+           x="191.63942"
+           y="6.131403"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text128"
+           style="stroke-width:0.264583">one-to-one o2o</text>
+        <line
+           x1="174.17691"
+           y1="10.629316"
+           x2="188.46442"
+           y2="10.629316"
+           stroke="#24b064"
+           stroke-width="2.91042"
+           stroke-linecap="round"
+           id="line128" />
+        <text
+           x="191.63942"
+           y="11.952234"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text129"
+           style="stroke-width:0.264583">many-to-many m2m</text>
+        <line
+           x1="259.37274"
+           y1="-1.0123465"
+           x2="273.66025"
+           y2="-1.0123465"
+           stroke="#f796f4"
+           stroke-width="2.91042"
+           stroke-linecap="round"
+           id="line129" />
+        <text
+           x="276.83524"
+           y="0.31056765"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text130"
+           style="stroke-width:0.264583">one-to-many o2m</text>
+        <line
+           x1="259.37274"
+           y1="4.808485"
+           x2="273.66025"
+           y2="4.808485"
+           stroke="#8a8a8a"
+           stroke-width="2.11667"
+           stroke-linecap="round"
+           stroke-dasharray="2.5, 4"
+           id="line130" />
+        <text
+           x="276.83524"
+           y="6.131403"
+           font-family="'DejaVu Sans', Verdana, Arial, Helvetica, sans-serif"
+           font-size="3.43958px"
+           font-weight="normal"
+           text-anchor="start"
+           fill="#111111"
+           id="text131"
+           style="stroke-width:0.264583">optional / alternative</text>
+      </g>
+    </g>
+    <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:7.05556px;line-height:1.93994px;font-family:'Maven Pro';-inkscape-font-specification:'Maven Pro Bold';text-align:center;writing-mode:lr-tb;direction:ltr;text-anchor:middle;fill:#050505;fill-opacity:1;stroke:none;stroke-width:0.529167;stroke-dashoffset:624.756"
-       x="102.42545"
-       y="72.967583"
-       id="text3-1"><tspan
-         sodipodi:role="line"
-         id="tspan3-2"
-         style="font-size:7.05556px;line-height:1.93994px;stroke-width:0.529167"
-         x="102.42545"
-         y="72.967583">QC</tspan></text></g><style
-     id="style22"
-     type="text/css">.st0{fill:#24af63}.st1{font-family:&quot;Maven Pro&quot;;font-weight:&quot;bold&quot;}.st2{font-size:209.8672px}.st4{fill:#ecdc86}.st7{fill:#396e35}</style></svg>
+       transform="scale(0.26458333)"
+       id="text37"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:16px;line-height:4.39923px;font-family:'DejaVu Sans Mono';-inkscape-font-specification:'DejaVu Sans Mono';text-align:center;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect37);display:inline;fill:#ffffff;fill-opacity:1;stroke:#666666;stroke-width:6.80315;stroke-linecap:square;stroke-linejoin:bevel;stroke-dasharray:5.66928, 5.66928;stroke-dashoffset:0;stroke-opacity:0.992157" />
+  </g>
+</svg>


### PR DESCRIPTION
I revised the pipeline's metro map based con comments from my colleagues and a draft by Claude.

The main change is that the direction of reading is linear whereas before it was from top-left to bottom-right.  What is optional is also more clearly labelled.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/pairgenomealign/tree/master/docs/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/pairgenomealign _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
